### PR TITLE
Update SEO bundle documentation with missing twig helpers

### DIFF
--- a/Resources/doc/reference/twig_helpers.rst
+++ b/Resources/doc/reference/twig_helpers.rst
@@ -1,20 +1,58 @@
 Twig Helpers
 ============
 
+Here are the Twig helpers you can use in your layout:
+
 Render the page title
+^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: jinja
 
     {{ sonata_seo_title() }}
 
-Render metadatas
+This will render page title as follow: <title>My custom title</title>
+
+Render page metadatas
+^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: jinja
 
     {{ sonata_seo_metadatas() }}
 
-Render html attributes
+This will render page metadatas as follow: <meta name="my-meta-name" content="my-value" />
+
+Render HTML attributes
+^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: jinja
 
     {{ sonata_seo_html_attributes() }}
+
+This will render page HTML attributes as follow: my-attribute="my-value"
+
+Render head attributes
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: jinja
+
+    {{ sonata_seo_head_attributes() }}
+
+This will render page head attributes as follow: my-attribute="my-value"
+
+Render canonical link
+^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: jinja
+
+    {{ sonata_seo_link_canonical() }}
+
+This will render page canonical link as follow: <link rel="canonical" href="http://www.example.com/"/>
+
+Render alternates languages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: jinja
+
+    {{ sonata_seo_lang_alternates() }}
+
+This will render page alternates languages as follow: <link rel="alternate" href="http://www.example.com/en" hreflang="en"/>

--- a/Resources/doc/reference/usage.rst
+++ b/Resources/doc/reference/usage.rst
@@ -58,6 +58,8 @@ These values can be used inside a twig template.
 
     <!DOCTYPE html>
     <html {{ sonata_seo_html_attributes() }}>
-        <head>
+        <head {{ sonata_seo_head_attributes() }}>
             {{ sonata_seo_title() }}
             {{ sonata_seo_metadatas() }}
+            {{ sonata_seo_link_canonical() }}
+            {{ sonata_seo_lang_alternates() }}


### PR DESCRIPTION
I've improved SonataSeoBundle documentation with some missing Twig helpers
