### PR TITLE
WIP: allow to add any links to seo page

### DIFF
--- a/Seo/SeoPage.php
+++ b/Seo/SeoPage.php
@@ -32,6 +32,13 @@ class SeoPage implements SeoPageInterface
     protected $langAlternates;
 
     /**
+     * Meta links
+     *
+     * @var array
+     */
+    protected $links = array();
+
+    /**
      * {@inheritdoc}
      */
     public function __construct($title = '')
@@ -214,7 +221,7 @@ class SeoPage implements SeoPageInterface
      */
     public function setLinkCanonical($link)
     {
-        $this->linkCanonical = $link;
+        $this->setLink('canonical', array('href' => $link));
 
         return $this;
     }
@@ -224,7 +231,11 @@ class SeoPage implements SeoPageInterface
      */
     public function getLinkCanonical()
     {
-        return $this->linkCanonical;
+        if (null !== $link = $this->getLink('canonical')) {
+            return $link[0]['href'];
+        }
+
+        return null;
     }
 
     /**
@@ -240,7 +251,9 @@ class SeoPage implements SeoPageInterface
      */
     public function setLangAlternates(array $langAlternates)
     {
-        $this->langAlternates= $langAlternates;
+        $this->links["alternate"] = array();
+        list($href, $hrefLang) = each($langAlternates);
+        $this->addLangAlternate($href, $hrefLang);
 
         return $this;
     }
@@ -250,7 +263,7 @@ class SeoPage implements SeoPageInterface
      */
     public function addLangAlternate($href, $hrefLang)
     {
-        $this->langAlternates[$href] = $hrefLang;
+        $this->addLink('alternate', array('href' => $href, 'hreflang' => $hrefLang));
 
         return $this;
     }
@@ -260,6 +273,47 @@ class SeoPage implements SeoPageInterface
      */
     public function getLangAlternates()
     {
-        return  $this->langAlternates;
+        if (null !== $links = $this->getLink('alternate')) {
+            $return = array();
+            foreach ($links as $element) {
+                $return[$element['href']] = $element['hreflang'];
+            }
+            return $return;
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addLink($type, array $attributes)
+    {
+        $this->links[$type][] = $attributes;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLink($type, array $attributes)
+    {
+        $this->links[$type] = array();
+
+        return $this->addLink($type, $attributes);
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLink($type)
+    {
+        if (isset($this->links[$type])) {
+            return $this->links[$type];
+        }
+
+        return null;
     }
 }

--- a/Tests/Seo/SeoPageTest.php
+++ b/Tests/Seo/SeoPageTest.php
@@ -132,4 +132,14 @@ class SeoPageTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($page->hasMeta('property', 'test'));
         $this->assertFalse($page->hasMeta('property', 'fake'));
     }
+
+    /**
+     * The getLink should always return links se by addLink
+     */
+    public function testAddLink()
+    {
+        $page = new SeoPage();
+        $page->addLink('prev', array('href' => 'http://google.com'));
+        $this->assertEquals(array(array('href' => 'http://google.com')), $page->getLink('prev'));
+    }
 }


### PR DESCRIPTION
Mostly to cover cases like 

```html
<link rel="prev" href="http://www.example.com/article?story=abc&page=1" />
<link rel="next" href="http://www.example.com/article?story=abc&page=3" />
<link rel=”publisher” href=”https://plus.google.com/[YOUR BUSINESS G+ PROFILE HERE]“/>
```

Changes look slightly cumbersome to support BC. Let me know if you would like me to proceed with changes like that and if you want to do a BC break. 

Tasks:
 - [ ] add twig helpers to render all link elements