### PR TITLE
Fix facebook share button widget

### DIFF
--- a/Resources/views/Block/block_facebook_share_button.html.twig
+++ b/Resources/views/Block/block_facebook_share_button.html.twig
@@ -16,7 +16,7 @@ file that was distributed with this source code.
     <div class="fb-share-button"
         {% if settings.url %}data-href="{{ settings.url }}"{% endif %}
         {% if settings.width %}data-width="{{ settings.width }}"{% endif %}
-        data-layout="{{ settings.layout }}">
+        data-type="{{ settings.layout }}">
     </div>
 
 {% endspaceless %}


### PR DESCRIPTION
According to the [Facebook documentation](https://developers.facebook.com/docs/plugins/share-button) layout settings must be configured with `data-type` HTML5 attribute
