### PR TITLE
Appending metadata instead of overriding.

### DIFF
--- a/Seo/SeoPage.php
+++ b/Seo/SeoPage.php
@@ -96,9 +96,42 @@ class SeoPage implements SeoPageInterface
             $this->metas[$type] = array();
         }
 
+        if (isset($this->metas[$type][$name])) {
+            if (!is_array(current($this->metas[$type][$name]))) {
+                $meta = $this->metas[$type][$name];
+
+                $this->metas[$type][$name] = array();
+                array_push($this->metas[$type][$name], $meta);
+            }
+
+            array_push($this->metas[$type][$name], array($content, $extras));
+        } else {
+            $this->metas[$type][$name] = array($content, $extras);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setMeta($type, $name, $content, array $extras = array())
+    {
+        if (!isset($this->metas[$type])) {
+            $this->metas[$type] = array();
+        }
+
         $this->metas[$type][$name] = array($content, $extras);
 
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMeta($type, $name)
+    {
+        return $this->hasMeta($type, $name) ? $this->metas[$type][$name] : null;
     }
 
     /**

--- a/Seo/SeoPageInterface.php
+++ b/Seo/SeoPageInterface.php
@@ -44,6 +44,24 @@ interface SeoPageInterface
     /**
      * @param string $type
      * @param string $name
+     * @param string $value
+     * @param array  $extras
+     *
+     * @return mixed
+     */
+    public function setMeta($type, $name, $value, array $extras = array());
+
+    /**
+     * @param string $type
+     * @param string $name
+     *
+     * @return array|null
+     */
+    public function getMeta($type, $name);
+
+    /**
+     * @param string $type
+     * @param string $name
      *
      * @return bool
      */

--- a/Tests/Seo/SeoPageTest.php
+++ b/Tests/Seo/SeoPageTest.php
@@ -30,6 +30,30 @@ class SeoPageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $page->getMetas());
     }
 
+    public function testAddMultipleValueToMeta()
+    {
+        $page = new SeoPage;
+        $page->addMeta('property', 'foo', 'bar');
+        $page->addMeta('property', 'foo', 'bar2');
+        $page->addMeta('property', 'foo', 'bar3');
+        $page->addMeta('property', 'foo', 'bar4');
+
+        $expected = array(
+            'http-equiv' => array(),
+            'name'       => array(),
+            'schema'     => array(),
+            'charset'    => array(),
+            'property'   => array('foo' => array(
+                array('bar', array()),
+                array('bar2', array()),
+                array('bar3', array()),
+                array('bar4', array()),
+            )),
+        );
+
+        $this->assertEquals($expected, $page->getMetas());
+    }
+
     public function testOverrideMetas()
     {
         $page = new SeoPage;

--- a/Twig/Extension/SeoExtension.php
+++ b/Twig/Extension/SeoExtension.php
@@ -67,18 +67,31 @@ class SeoExtension extends \Twig_Extension
     /**
      * @return void
      */
+    public function renderMetadata($type, $name, $meta)
+    {
+        list($content, $extras) = $meta;
+
+        echo sprintf("<meta %s=\"%s\" content=\"%s\" />\n",
+            $type,
+            $this->normalize($name),
+            $this->normalize($content)
+        );
+    }
+
+    /**
+     * @return void
+     */
     public function renderMetadatas()
     {
         foreach ($this->page->getMetas() as $type => $metas) {
             foreach ((array) $metas as $name => $meta) {
-                list($content, $extras) = $meta;
-
-                echo sprintf("<meta %s=\"%s\" content=\"%s\" />\n",
-                    $type,
-                    $this->normalize($name),
-                    $this->normalize($content)
-                );
-
+                if (is_array(current($meta))) {
+                    foreach ($meta as $m) {
+                        $this->renderMetadata($type, $name, $m);
+                    }
+                } else {
+                    $this->renderMetadata($type, $name, $meta);
+                }
             }
         }
     }


### PR DESCRIPTION
There is a case when you want to append the same metadatas.

For example, 'og:image', we could provide several of 'og:image' metadatas for sharer to crawl.