### PR TITLE
Use the configuration class for the bundle config

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -25,6 +25,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('default')->defaultValue('sonata.seo.page.default')->end()
                         ->arrayNode('head')
+                            ->normalizeKeys(false)
                             ->useAttributeAsKey('attribute')
                             ->prototype('scalar')->end()
                         ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -7,40 +7,48 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
  * This is the class that validates and merges configuration from your app/config files
- *
- * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
  */
 class Configuration implements ConfigurationInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('sonata_seo');
 
-        $rootNode
+        $treeBuilder->root('sonata_seo')
             ->children()
+                ->scalarNode('encoding')->defaultValue('UTF-8')->end()
                 ->arrayNode('page')
-                    ->scalarNode('encoding')->defaultValue('UTF-8')->end()
-                    ->scalarNode('default')->defaultValue('sonata.seo.page.default')->end()
-                    ->scalarNode('separator')->defaultValue(' - ')->end()
-                    ->scalarNode('title')->defaultValue('Sonata Project')->end()
-                    ->arrayNode('metas')
-                        ->useAttributeAsKey('id')
-                        ->prototype('array')
-                            ->useAttributeAsKey('id')
-                            ->prototype('variable')->end()
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('default')->defaultValue('sonata.seo.page.default')->end()
+                        ->arrayNode('head')
+                            ->useAttributeAsKey('attribute')
+                            ->prototype('scalar')->end()
                         ->end()
-                    ->end()
-                    ->arrayNode('head')
-                        ->useAttributeAsKey('id')
-                        ->children()
-                            ->arrayNode('attributes')
-                                ->useAttributeAsKey('id')
+                        ->arrayNode('metas')
+                            ->normalizeKeys(false)
+                            ->useAttributeAsKey('element')
+                            ->prototype('array')
+                                ->normalizeKeys(false)
+                                ->useAttributeAsKey('name')
                                 ->prototype('scalar')->end()
                             ->end()
+                        ->end()
+                        ->scalarNode('separator')->defaultValue(' - ')->end()
+                        ->scalarNode('title')->defaultValue('Sonata Project')->end()
+                    ->end()
+                ->end()
+                ->arrayNode('sitemap')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('doctrine_orm')
+                            ->prototype('variable')->end()
+                        ->end()
+                        ->arrayNode('services')
+                            ->prototype('variable')->end()
                         ->end()
                     ->end()
                 ->end()

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Sonata\SeoBundle\Tests\DependencyInjection;
+
+use Sonata\SeoBundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\Processor;
+
+class ConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+
+    private function getDefaultConfiguration()
+    {
+        return array(
+            'encoding' => 'UTF-8',
+            'page' => array(
+                'default' => 'sonata.seo.page.default',
+                'head' => array(),
+                'metas' => array(),
+                'separator' => ' - ',
+                'title' => 'Sonata Project',
+            ),
+            'sitemap' => array(
+                'doctrine_orm' => array(),
+                'services' => array(),
+            ),
+        );
+    }
+
+    private function processConfiguration(array $configs)
+    {
+        $configuration = new Configuration();
+        $processor = new Processor();
+
+        return $processor->processConfiguration($configuration, $configs);
+    }
+
+    public function testDefaultConfiguration()
+    {
+        $config = $this->processConfiguration(array(array()));
+
+        $expected = $this->getDefaultConfiguration();
+
+        $this->assertEquals($expected, $config);
+    }
+
+    public function testKeysAreNotNormalized()
+    {
+        $values = array(
+            'page' => array(
+                'metas' => array(
+                    'http-equiv' => array(
+                        'Content-Type' => 'text/html; charset=utf-8',
+                    ),
+                ),
+            ),
+        );
+
+        $config = $this->processConfiguration(array($values));
+
+        $expected = array_merge_recursive(
+            $this->getDefaultConfiguration(),
+            $values
+        );
+
+        $this->assertEquals($expected, $config);
+    }
+
+}

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -48,6 +48,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         $values = array(
             'page' => array(
+                'head' => array('data-example' => 'abc-123'),
                 'metas' => array(
                     'http-equiv' => array(
                         'Content-Type' => 'text/html; charset=utf-8',

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -4,6 +4,7 @@ namespace Sonata\SeoBundle\Tests\DependencyInjection;
 
 use Sonata\SeoBundle\DependencyInjection\Configuration;
 use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Yaml\Yaml;
 
 class ConfigurationTest extends \PHPUnit_Framework_TestCase
 {
@@ -54,6 +55,20 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 ),
             ),
         );
+
+        $config = $this->processConfiguration(array($values));
+
+        $expected = array_merge_recursive(
+            $this->getDefaultConfiguration(),
+            $values
+        );
+
+        $this->assertEquals($expected, $config);
+    }
+
+    public function testWithYamlConfig()
+    {
+        $values = Yaml::parse(__DIR__ . '/data/config.yml', true);
 
         $config = $this->processConfiguration(array($values));
 

--- a/Tests/DependencyInjection/data/config.yml
+++ b/Tests/DependencyInjection/data/config.yml
@@ -1,0 +1,11 @@
+# Test data for sonata_seo
+page:
+    head:
+        'xmlns:og': 'http://ogp.me/ns#'
+
+    metas:
+        http-equiv:
+            Content-Type: 'text/html; charset=utf-8'
+
+        name:
+            robots: 'index, follow'


### PR DESCRIPTION
This pull request:
- Makes it possible to split the sonata_seo configs over multiple config files
- Makes ``app/console config:dump-reference SonataSeoBundle`` work (fixes #59)

I tested with the config from http://sonata-project.org/bundles/seo/master/doc/reference/usage.html

AFAIK this pull request is BC but if that is not the case please let me know so I can fix that.