### PR TITLE
Added oEmbed support

### DIFF
--- a/Resources/doc/reference/twig_helpers.rst
+++ b/Resources/doc/reference/twig_helpers.rst
@@ -72,3 +72,17 @@ This will render page alternate languages as follows:
 .. code-block:: html
 
     <link rel="alternate" href="http://www.example.com/en" hreflang="en"/>
+
+
+Render oEmbed links (http://www.oembed.com/)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: jinja
+
+    {{ sonata_seo_oembed_links() }}
+
+This will render oEmbed links as follows:
+
+.. code-block:: html
+
+    <link rel="alternate" type="application/json+oembed" href="http://flickr.com/services/oembed?url=http%3A%2F%2Fflickr.com%2Fphotos%2Fbees%2F2362225867%2F&format=json" title="Bacon Lollys oEmbed Profile" />

--- a/Seo/SeoPage.php
+++ b/Seo/SeoPage.php
@@ -31,6 +31,8 @@ class SeoPage implements SeoPageInterface
 
     protected $langAlternates;
 
+    protected $oembedLinks;
+
     /**
      * {@inheritdoc}
      */
@@ -49,6 +51,7 @@ class SeoPage implements SeoPageInterface
         $this->linkCanonical = '';
         $this->separator = ' ';
         $this->langAlternates = array();
+        $this->oembedLinks = array();
     }
 
     /**
@@ -261,5 +264,25 @@ class SeoPage implements SeoPageInterface
     public function getLangAlternates()
     {
         return  $this->langAlternates;
+    }
+
+    /**
+     * @param $title
+     * @param $link
+     * @return SeoPageInterface
+     */
+    public function addOEmbedLink($title, $link)
+    {
+        $this->oembedLinks[$title] = $link;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOEmbedLinks()
+    {
+        return $this->oembedLinks;
     }
 }

--- a/Seo/SeoPageInterface.php
+++ b/Seo/SeoPageInterface.php
@@ -138,4 +138,16 @@ interface SeoPageInterface
      * @return array
      */
     public function getLangAlternates();
+
+    /**
+     * @param $title
+     * @param $link
+     * @return SeoPageInterface
+     */
+    public function addOEmbedLink($title, $link);
+
+    /**
+     * @return array
+     */
+    public function getOEmbedLinks();
 }

--- a/Tests/Twig/Extension/SeoExtensionTest.php
+++ b/Tests/Twig/Extension/SeoExtensionTest.php
@@ -111,4 +111,16 @@ class BlockTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals("<link rel=\"alternate\" href=\"http://example.com/\" hreflang=\"x-default\"/>\n", $extension->getLangAlternates());
     }
+
+    public function testOEmbedLinks()
+    {
+        $page = $this->getMock('Sonata\SeoBundle\Seo\SeoPageInterface');
+        $page->expects($this->once())->method('getOembedLinks')->will($this->returnValue(array(
+            'Foo' => 'http://example.com/',
+        )));
+
+        $extension = new SeoExtension($page, 'UTF-8');
+
+        $this->assertEquals("<link rel=\"alternate\" type=\"application/json+oembed\" href=\"http://example.com/\" title=\"Foo\" />\n", $extension->getOembedLinks());
+    }
 }

--- a/Twig/Extension/SeoExtension.php
+++ b/Twig/Extension/SeoExtension.php
@@ -43,6 +43,7 @@ class SeoExtension extends \Twig_Extension
             new \Twig_SimpleFunction('sonata_seo_head_attributes', array($this, 'getHeadAttributes'), array('is_safe' => array('html'))),
             new \Twig_SimpleFunction('sonata_seo_link_canonical', array($this, 'getLinkCanonical'), array('is_safe' => array('html'))),
             new \Twig_SimpleFunction('sonata_seo_lang_alternates', array($this, 'getLangAlternates'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('sonata_seo_oembed_links', array($this, 'getOembedLinks'), array('is_safe' => array('html'))),
         );
     }
 
@@ -196,6 +197,19 @@ class SeoExtension extends \Twig_Extension
         $html = '';
         foreach ($this->page->getLangAlternates() as $href => $hrefLang) {
             $html .= sprintf("<link rel=\"alternate\" href=\"%s\" hreflang=\"%s\"/>\n", $href, $hrefLang);
+        }
+
+        return $html;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOembedLinks()
+    {
+        $html = '';
+        foreach ($this->page->getOEmbedLinks() as $title => $link) {
+            $html .= sprintf("<link rel=\"alternate\" type=\"application/json+oembed\" href=\"%s\" title=\"%s\" />\n", $link, $title);
         }
 
         return $html;


### PR DESCRIPTION
Added support for [oEmbed](http://www.oembed.com/) which is used to embed rich content by platforms like [wordpress](http://codex.wordpress.org/Embeds#oEmbed)

