### PR TITLE
Fix twitter sdk twig block name

### DIFF
--- a/Resources/views/Block/_twitter_sdk.html.twig
+++ b/Resources/views/Block/_twitter_sdk.html.twig
@@ -8,7 +8,7 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% block facebook_sdk %}
+{% block twitter_sdk %}
 {% spaceless %}
 
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>


### PR DESCRIPTION
block name was wrong in twig template. It worked like it should but you cannot override the block correctly.