### PR TITLE
Fix bundle config example in docs

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -27,9 +27,9 @@ file.
 
     # app/config/config.yml
     sonata_seo:
-        default:          sonata.seo.page.default
         encoding:         UTF-8
         page:
+            default: sonata.seo.page.default
             title:            Sonata Project
             metas:
                 name:


### PR DESCRIPTION
According to this, the default key should be underneath page, right? 
https://github.com/sonata-project/SonataSeoBundle/blob/master/DependencyInjection/Configuration.php#L26