### PR TITLE
Context is missing in breadcrumb service

### DIFF
--- a/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
+++ b/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
@@ -97,6 +97,7 @@ abstract class BaseBreadcrumbMenuBlockService extends MenuBlockService
         $resolver->setDefaults(array(
             'menu_template'         => 'SonataSeoBundle:Block:breadcrumb.html.twig',
             'include_homepage_link' => true,
+            'context'               => false,
         ));
     }
 


### PR DESCRIPTION
The 'context' setting is missing in the breadcrumb service. This could be an error when rendering the breadcrumb using "sonata_block_render_event".

This would also throw an exception in https://github.com/sonata-project/SonataBlockBundle/blob/master/Block/BlockContextManager.php#L259 because the 'context' setting is unknown.

Please check these pr's as well
* [x] sonata-project/SonataMediaBundle#834
* [x] sonata-project/SonataNewsBundle#251 