### PR TITLE
Avoided blocks.xml loading when KnpMenuBundle is missing #56

### DIFF
--- a/DependencyInjection/SonataSeoExtension.php
+++ b/DependencyInjection/SonataSeoExtension.php
@@ -28,7 +28,7 @@ class SonataSeoExtension extends Extension
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
-        if (isset($bundles['SonataBlockBundle'])) {
+        if (isset($bundles['SonataBlockBundle']) && isset($bundles['KnpMenuBundle'])) {
             $loader->load('blocks.xml');
         }
 

--- a/Tests/DependencyInjection/SonataSeoExtensionTest.php
+++ b/Tests/DependencyInjection/SonataSeoExtensionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\SeoBundle\Tests\DependencyInjection;
+
+use Sonata\SeoBundle\DependencyInjection\SonataSeoExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Tests SonataSeoExtension.
+ *
+ * @author Vincent Tommasi <tommasi.v@gmail.com>
+ */
+class SonataSeoExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests the loading of blocks.xml file.
+     */
+    public function testBlocksLoading()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.bundles', array(
+            'SonataBlockBundle' => 'Sonata\BlockBundle\SonataBlockBundle',
+            'KnpMenuBundle'     => 'Knp\Bundle\MenuBundle\KnpMenuBundle',
+        ));
+
+        $extension = new SonataSeoExtension();
+        $extension->load(array(array()), $container);
+
+        $this->assertTrue($container->hasDefinition('sonata.seo.block.breadcrumb.homepage'));
+
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.bundles', array());
+        $extension->load(array(array()), $container);
+
+        $this->assertFalse($container->hasDefinition('sonata.seo.block.breadcrumb.homepage'));
+    }
+}


### PR DESCRIPTION
After installing SonataSeoBundle in our project, this error popped out :

`The service "sonata.seo.block.breadcrumb.homepage" has a dependency on a non-existent service "knp_menu.menu_provider".`

Actually, KnpMenuBundle is also needed to load the `blocks.xml` file so, since it's optional, it's probably better to avoid to load that file than to add a new dependency.