### PR TITLE
Allow SonataBlockBundle 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,18 +17,18 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "~2.3|~3.0",
-        "symfony/options-resolver": "~2.3|~3.0",
+        "symfony/framework-bundle": "~2.3 || ~3.0",
+        "symfony/options-resolver": "~2.3 || ~3.0",
         "sonata-project/exporter": "~1.2,>=1.2.2",
-        "sonata-project/block-bundle": "^2.3.9",
+        "sonata-project/block-bundle": "^2.3.9 || ~3.0",
         "twig/twig": "~1.12"
     },
     "require-dev": {
         "guzzle/guzzle": "3.*",
-        "symfony/console": "~2.3|~3.0",
-        "symfony/finder": "~2.3|~3.0",
-        "sonata-project/admin-bundle": "~2.4",
-        "symfony/phpunit-bridge": "~2.7|~3.0"
+        "symfony/console": "~2.3 || ~3.0",
+        "symfony/finder": "~2.3 || ~3.0",
+        "sonata-project/admin-bundle": "~2.4 || ~3.0",
+        "symfony/phpunit-bridge": "~2.7 || ~3.0"
     },
     "suggest": {
         "guzzle/guzzle": "3.*",


### PR DESCRIPTION
Fixes #122 

I can't see any BC breaks between BlockBundle 2.3.11 and master, so I think 3.0-dev is already supported.