### PR TITLE
Default values

### DIFF
--- a/Block/Social/FacebookLikeButtonBlockService.php
+++ b/Block/Social/FacebookLikeButtonBlockService.php
@@ -54,9 +54,9 @@ class FacebookLikeButtonBlockService extends BaseFacebookSocialPluginsBlockServi
             'width' => null,
             'show_faces' => true,
             'share' => true,
-            'layout' => $this->layoutList['standard'],
-            'colorscheme' => $this->colorschemeList['light'],
-            'action' => $this->actionTypes['like'],
+            'layout'      => 'standard',
+            'colorscheme' => 'light',
+            'action'      => 'like',
         ));
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->
Change default values of facebook block
```markdown
### Added

### Changed
- FacebookLikeButtonBlockService

### Deprecated

### Removed

### Fixed

### Security
```

### Subject

<!-- Describe your Pull Request content here -->

### To do

<!--
    Complete the tasks.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

- [ ] My PR stuff
- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

I think facebook has recently enforced the colorscheme value. It must be light or dark.
There is an error and it was setting the form label.
eg. `form.label_colorscheme_light`