### PR TITLE
Suggest HTTPlug instead of Guzzle implementation

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,6 +1,13 @@
 UPGRADE 2.x
 ===========
 
+## TwitterEmbedTweetBlockService uses HTTPlug
+
+The `Guzzle` dependency was removed and replaced with the abstract `HTTPlug` client, so you can choose your preferred 
+http client implementation. If you have extended the `TwitterEmbedTweetBlockService` class, you need to adjust the 
+constructor signature.
+
+
 UPGRADE FROM 2.2 to 2.3
 =======================
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,10 @@
         "sonata-project/block-bundle": "<3.11"
     },
     "require-dev": {
-        "guzzle/guzzle": "^3.8",
+        "guzzlehttp/guzzle": "^6.0",
+        "php-http/httplug": "^1.1 || ^2.0",
+        "php-http/httplug-bundle": "^1.14",
+        "php-http/mock-client": "^0.3",
         "sonata-project/admin-bundle": "^3.31",
         "sonata-project/block-bundle": "^3.11",
         "sonata-project/core-bundle": "^3.9",
@@ -46,8 +49,9 @@
         "symfony/yaml": "^2.8 || ^3.2 || ^4.0"
     },
     "suggest": {
-        "guzzle/guzzle": "3.*",
-        "knplabs/knp-menu-bundle": "Used by the BreadcrumbMenuBuilder"
+        "knplabs/knp-menu-bundle": "Used by the BreadcrumbMenuBuilder",
+        "php-http/buzz-adapter": "Buzz HTTP client implementation for TwitterEmbedTweetBlockService",
+        "php-http/guzzle6-adapter": "Guzzle HTTP client implementation for TwitterEmbedTweetBlockService"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "guzzlehttp/guzzle": "^6.0",
         "php-http/httplug": "^1.1 || ^2.0",
         "php-http/httplug-bundle": "^1.13",
-        "php-http/mock-client": "^0.3",
+        "php-http/mock-client": "^1.1",
         "sonata-project/admin-bundle": "^3.31",
         "sonata-project/block-bundle": "^3.11",
         "sonata-project/core-bundle": "^3.9",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require-dev": {
         "guzzlehttp/guzzle": "^6.0",
         "php-http/httplug": "^1.1 || ^2.0",
-        "php-http/httplug-bundle": "^1.14",
+        "php-http/httplug-bundle": "^1.13",
         "php-http/mock-client": "^0.3",
         "sonata-project/admin-bundle": "^3.31",
         "sonata-project/block-bundle": "^3.11",

--- a/docs/reference/social_blocks.rst
+++ b/docs/reference/social_blocks.rst
@@ -49,5 +49,12 @@ The ``sonata.seo.block.twitter.embed`` allows you to embed a tweet by giving its
 or embed content. Please refer to `Embedded Tweets doc <https://dev.twitter.com/docs/embedded-tweets>`_
 and `OEmbed API doc <https://dev.twitter.com/docs/api/1/get/statuses/oembed>`_ for a full understanding.
 
-The block service allows you to ask the API if you've given an ID or a URL (you'll need to install the
-Guzzle library for this: ``composer require guzzle/guzzle``).
+The block service allows you to ask the API if you've given an ID or a URL .
+
+You'll need to install an HTTPlug client to request the Twitter API, for example the Guzzle adapter:
+
+.. code-block:: bash
+
+    composer require php-http/guzzle6-adapter
+
+More information can be found [here](https://php-http.readthedocs.io/en/latest/httplug/users.html).

--- a/src/Block/Social/TwitterEmbedTweetBlockService.php
+++ b/src/Block/Social/TwitterEmbedTweetBlockService.php
@@ -54,13 +54,7 @@ class TwitterEmbedTweetBlockService extends BaseTwitterButtonBlockService
      */
     private $messageFactory;
 
-    /**
-     * @param string          $name
-     * @param EngineInterface $templating
-     * @param HttpClient      $httpClient
-     * @param MessageFactory  $messageFactory
-     */
-    public function __construct($name, EngineInterface $templating, HttpClient $httpClient = null, MessageFactory $messageFactory = null)
+    public function __construct(?string $name, EngineInterface $templating, HttpClient $httpClient = null, MessageFactory $messageFactory = null)
     {
         parent::__construct($name, $templating);
 
@@ -68,10 +62,7 @@ class TwitterEmbedTweetBlockService extends BaseTwitterButtonBlockService
         $this->messageFactory = $messageFactory;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function execute(BlockContextInterface $blockContext, Response $response = null)
+    public function execute(BlockContextInterface $blockContext, Response $response = null): Response
     {
         return $this->renderResponse($blockContext->getTemplate(), [
             'block' => $blockContext->getBlock(),

--- a/src/Block/Social/TwitterEmbedTweetBlockService.php
+++ b/src/Block/Social/TwitterEmbedTweetBlockService.php
@@ -54,8 +54,12 @@ class TwitterEmbedTweetBlockService extends BaseTwitterButtonBlockService
      */
     private $messageFactory;
 
-    public function __construct(?string $name, EngineInterface $templating, HttpClient $httpClient = null, MessageFactory $messageFactory = null)
-    {
+    public function __construct(
+        ?string $name,
+        EngineInterface $templating,
+        HttpClient $httpClient = null,
+        MessageFactory $messageFactory = null
+    ) {
         parent::__construct($name, $templating);
 
         $this->httpClient = $httpClient;

--- a/src/Block/Social/TwitterEmbedTweetBlockService.php
+++ b/src/Block/Social/TwitterEmbedTweetBlockService.php
@@ -218,12 +218,8 @@ class TwitterEmbedTweetBlockService extends BaseTwitterButtonBlockService
 
     /**
      * Loads twitter tweet.
-     *
-     * @param BlockContextInterface $blockContext
-     *
-     * @return string|null
      */
-    private function loadTweet(BlockContextInterface $blockContext)
+    private function loadTweet(BlockContextInterface $blockContext): ?string
     {
         $uriMatched = preg_match(self::TWEET_URL_PATTERN, $blockContext->getSetting('tweet'));
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -81,10 +81,7 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 
-    /**
-     * @param ArrayNodeDefinition $node
-     */
-    private function addHTTPlugSection(ArrayNodeDefinition $node)
+    private function addHTTPlugSection(ArrayNodeDefinition $node): void
     {
         $node
             ->children()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -75,6 +76,31 @@ class Configuration implements ConfigurationInterface
             ->end()
         ;
 
+        $this->addHTTPlugSection($rootNode);
+
         return $treeBuilder;
+    }
+
+    /**
+     * @param ArrayNodeDefinition $node
+     */
+    private function addHTTPlugSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('http')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('client')
+                            ->defaultValue('httplug.client.default')
+                            ->info('Alias of the HTTPlug client.')
+                        ->end()
+                        ->scalarNode('message_factory')
+                            ->defaultValue('httplug.message_factory.default')
+                            ->info('Alias of the HTTPlug message factory.')
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
     }
 }

--- a/src/DependencyInjection/SonataSeoExtension.php
+++ b/src/DependencyInjection/SonataSeoExtension.php
@@ -171,11 +171,7 @@ class SonataSeoExtension extends Extension
         return $config;
     }
 
-    /**
-     * @param ContainerBuilder $container
-     * @param array            $config
-     */
-    private function configureHttpClient(ContainerBuilder $container, array $config)
+    private function configureHttpClient(ContainerBuilder $container, array $config): void
     {
         $container->setAlias('sonata.seo.http.client', $config['client']);
         $container->setAlias('sonata.seo.http.message_factory', $config['message_factory']);

--- a/src/DependencyInjection/SonataSeoExtension.php
+++ b/src/DependencyInjection/SonataSeoExtension.php
@@ -49,6 +49,7 @@ class SonataSeoExtension extends Extension
 
         $this->configureSeoPage($config['page'], $container);
         $this->configureSitemap($config['sitemap'], $container);
+        $this->configureHttpClient($container, $config['http']);
 
         $container->getDefinition('sonata.seo.twig.extension')
             ->replaceArgument(1, $config['encoding']);
@@ -168,5 +169,15 @@ class SonataSeoExtension extends Extension
         }
 
         return $config;
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $config
+     */
+    private function configureHttpClient(ContainerBuilder $container, array $config)
+    {
+        $container->setAlias('sonata.seo.http.client', $config['client']);
+        $container->setAlias('sonata.seo.http.message_factory', $config['message_factory']);
     }
 }

--- a/src/Resources/config/blocks.xml
+++ b/src/Resources/config/blocks.xml
@@ -74,6 +74,8 @@
             <tag name="sonata.block"/>
             <argument>sonata.seo.block.twitter.embed</argument>
             <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="sonata.seo.http.client" on-invalid="null"/>
+            <argument type="service" id="sonata.seo.http.message_factory" on-invalid="null"/>
         </service>
         <!-- Twitter embed -->
         <!-- Pinterest buttons -->

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -89,6 +89,10 @@ class ConfigurationTest extends TestCase
                 'doctrine_orm' => [],
                 'services' => [],
             ],
+            'http' => [
+                'client' => 'httplug.client.default',
+                'message_factory' => 'httplug.message_factory.default',
+            ],
         ];
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because this adds a new implementation without removing the existing one.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Added
- Added support for `HTTPlug` in `TwitterEmbedTweetBlockService`
```
## Subject

Added support for an abstract http client without removing the existing old guzzle implementation.
