### PR TITLE
Added support for disabled translation in breadcrumb

### DIFF
--- a/Resources/views/Block/breadcrumb.html.twig
+++ b/Resources/views/Block/breadcrumb.html.twig
@@ -10,7 +10,17 @@ file that was distributed with this source code.
 #}
 
 {% extends 'knp_menu_ordered.html.twig' %}
-{% block label %}{{ item.label|trans(item.getExtra('translation_params', {}), item.getExtra('translation_domain', 'SonataSeoBundle')) }}{% endblock %}
+
+{% block label %}
+    {% set translation_domain = item.getExtra('translation_domain', 'SonataSeoBundle') %}
+    {% if options.allow_safe_labels and item.extra('safe_label', false) %}
+        {{- item.label|raw -}}
+    {% elseif translation_domain is sameas(false) %}
+        {{- item.label -}}
+    {% else %}
+        {{- item.label|trans(item.getExtra('translation_params', {}), translation_domain) -}}
+    {% endif %}
+{% endblock %}
 
 {% block list %}
 {% spaceless %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support for `safe_label` in breadcrumb
- Added support for `false` translation in breadcrumb
```

## Subject

Added support for `safe_label` to display raw html and `translation_domain: false` to disable translation.

