### PR TITLE
better deprecation handling for methods in SeoExtension

### DIFF
--- a/Twig/Extension/SeoExtension.php
+++ b/Twig/Extension/SeoExtension.php
@@ -62,10 +62,16 @@ class SeoExtension extends \Twig_Extension
     /**
      * NEXT_MAJOR: remove this method.
      *
-     * @deprecated Deprecated as of 1.2, echo the return value of getTitle() instead
+     * @deprecated since 2.0, to be removed in 3.0
      */
     public function renderTitle()
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since 2.0, to be removed in 3.0. '.
+            'Use '.__NAMESPACE__.'::getTitle() instead.',
+            E_USER_DEPRECATED
+        );
+
         echo $this->getTitle();
     }
 
@@ -80,10 +86,16 @@ class SeoExtension extends \Twig_Extension
     /**
      * NEXT_MAJOR: remove this method.
      *
-     * @deprecated Deprecated as of 1.2, echo the return value of getMetadatas() instead
+     * @deprecated since 2.0, to be removed in 3.0
      */
     public function renderMetadatas()
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since 2.0, to be removed in 3.0. '.
+            'Use '.__NAMESPACE__.'::getMetadatas() instead.',
+            E_USER_DEPRECATED
+        );
+
         echo $this->getMetadatas();
     }
 
@@ -118,10 +130,16 @@ class SeoExtension extends \Twig_Extension
     /**
      * NEXT_MAJOR: remove this method.
      *
-     * @deprecated Deprecated as of 1.2, echo the return value of getHtmlAttributes() instead
+     * @deprecated since 2.0, to be removed in 3.0
      */
     public function renderHtmlAttributes()
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since 2.0, to be removed in 3.0. '.
+            'Use '.__NAMESPACE__.'::getHtmlAttributes() instead.',
+            E_USER_DEPRECATED
+        );
+
         echo $this->getHtmlAttributes();
     }
 
@@ -141,10 +159,16 @@ class SeoExtension extends \Twig_Extension
     /**
      * NEXT_MAJOR: remove this method.
      *
-     * @deprecated Deprecated as of 1.2, echo the return value of getHeadAttributes() instead
+     * @deprecated since 2.0, to be removed in 3.0
      */
     public function renderHeadAttributes()
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since 2.0, to be removed in 3.0. '.
+            'Use '.__NAMESPACE__.'::getHeadAttributes() instead.',
+            E_USER_DEPRECATED
+        );
+
         echo $this->getHeadAttributes();
     }
 
@@ -164,10 +188,16 @@ class SeoExtension extends \Twig_Extension
     /**
      * NEXT_MAJOR: remove this method.
      *
-     * @deprecated Deprecated as of 1.2, echo the return value of getLinkCanonical() instead
+     * @deprecated since 2.0, to be removed in 3.0
      */
     public function renderLinkCanonical()
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since 2.0, to be removed in 3.0. '.
+            'Use '.__NAMESPACE__.'::getLinkCanonical() instead.',
+            E_USER_DEPRECATED
+        );
+
         echo $this->getLinkCanonical();
     }
 
@@ -184,10 +214,16 @@ class SeoExtension extends \Twig_Extension
     /**
      * NEXT_MAJOR: remove this method.
      *
-     * @deprecated Deprecated as of 1.2, echo the return value of getLangAlternates() instead
+     * @deprecated since 2.0, to be removed in 3.0
      */
     public function renderLangAlternates()
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since 2.0, to be removed in 3.0. '.
+            'Use '.__NAMESPACE__.'::getLangAlternates() instead.',
+            E_USER_DEPRECATED
+        );
+
         echo $this->getLangAlternates();
     }
 

--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,6 +1,17 @@
 UPGRADE 2.x
 ===========
 
+### Deprecated methods in `Sonata\SeoBundle\Twig\Extension`
+
+| deprecated method | recommended method |
+|-------------------------|-----------------------------|
+| `renderTitle()` | `getTitle()` |
+| `renderMetadatas()` | `getMetadatas()` |
+| `renderHtmlAttributes()` | `getHtmlAttributes()` |
+| `renderHeadAttributes()` | `getHeadAttributes()` |
+| `renderLinkCanonical()` | `getLinkCanonical()` |
+| `renderLangAlternates()` | `getLangAlternates()` |
+
 ### Tests
 
 All files under the ``Tests`` directory are now correctly handled as internal test classes. 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `Sonata\SeoBundle\Twig\Extension::renderTitle()` in favor of `Sonata\SeoBundle\Twig\Extension::getTitle()`
- `Sonata\SeoBundle\Twig\Extension::renderMetadatas()` in favor of `Sonata\SeoBundle\Twig\Extension::getMetadatas()`
- `Sonata\SeoBundle\Twig\Extension::renderHtmlAttributes()` in favor of `Sonata\SeoBundle\Twig\Extension::getHtmlAttributes()`
- `Sonata\SeoBundle\Twig\Extension::renderHeadAttributes()` in favor of `Sonata\SeoBundle\Twig\Extension::getHeadAttributes()`
- `Sonata\SeoBundle\Twig\Extension::renderLinkCanonical()` in favor of `Sonata\SeoBundle\Twig\Extension::getLinkCanonical()`
- `Sonata\SeoBundle\Twig\Extension::renderLangAlternates()` in favor of `Sonata\SeoBundle\Twig\Extension::getLangAlternates()`
```
