### PR TITLE
use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService instead of deprecated Sonata\BlockBundle\Block\BaseBlockService

### DIFF
--- a/Block/Social/BaseFacebookSocialPluginsBlockService.php
+++ b/Block/Social/BaseFacebookSocialPluginsBlockService.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\SeoBundle\Block\Social;
 
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
-abstract class BaseFacebookSocialPluginsBlockService extends BaseBlockService
+abstract class BaseFacebookSocialPluginsBlockService extends AbstractAdminBlockService
 {
     /**
      * @var string[]

--- a/Block/Social/BaseTwitterButtonBlockService.php
+++ b/Block/Social/BaseTwitterButtonBlockService.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\SeoBundle\Block\Social;
 
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
-abstract class BaseTwitterButtonBlockService extends BaseBlockService
+abstract class BaseTwitterButtonBlockService extends AbstractAdminBlockService
 {
     /**
      * @var string[]

--- a/Block/Social/EmailShareButtonBlockService.php
+++ b/Block/Social/EmailShareButtonBlockService.php
@@ -12,8 +12,8 @@
 namespace Sonata\SeoBundle\Block\Social;
 
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Model\Metadata;
 use Symfony\Component\HttpFoundation\Response;
@@ -24,7 +24,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
-class EmailShareButtonBlockService extends BaseBlockService
+class EmailShareButtonBlockService extends AbstractAdminBlockService
 {
     /**
      * {@inheritdoc}

--- a/Block/Social/PinterestPinButtonBlockService.php
+++ b/Block/Social/PinterestPinButtonBlockService.php
@@ -12,8 +12,8 @@
 namespace Sonata\SeoBundle\Block\Social;
 
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Model\Metadata;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,7 +26,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
-class PinterestPinButtonBlockService extends BaseBlockService
+class PinterestPinButtonBlockService extends AbstractAdminBlockService
 {
     /**
      * {@inheritdoc}

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/framework-bundle": "^2.3 || ^3.0",
         "symfony/options-resolver": "^2.3 || ^3.0",
         "sonata-project/exporter": "^1.2.2",
-        "sonata-project/block-bundle": "^3.1.1",
+        "sonata-project/block-bundle": "^3.2",
         "twig/twig": "^1.12"
     },
     "require-dev": {


### PR DESCRIPTION

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- use `Sonata\BlockBundle\Block\Service\AbstractAdminBlockService` instead of deprecated `Sonata\BlockBundle\Block\BaseBlockService`
```
