### PR TITLE
Fix wrong help_block form option for sonata.seo.block.twitter.embed block

### DIFF
--- a/src/Block/Social/TwitterEmbedTweetBlockService.php
+++ b/src/Block/Social/TwitterEmbedTweetBlockService.php
@@ -94,27 +94,27 @@ class TwitterEmbedTweetBlockService extends BaseTwitterButtonBlockService
                 array('tweet', 'textarea', array(
                     'required' => true,
                     'label' => 'form.label_tweet',
-                    'help_block' => 'form.help_tweet',
+                    'sonata_help' => 'form.help_tweet',
                 )),
                 array('maxwidth', 'integer', array(
                     'required' => false,
                     'label' => 'form.label_maxwidth',
-                    'help_block' => 'form.help_maxwidth',
+                    'sonata_help' => 'form.help_maxwidth',
                 )),
                 array('hide_media', 'checkbox', array(
                     'required' => false,
                     'label' => 'form.label_hide_media',
-                    'help_block' => 'form.help_hide_media',
+                    'sonata_help' => 'form.help_hide_media',
                 )),
                 array('hide_thread', 'checkbox', array(
                     'required' => false,
                     'label' => 'form.label_hide_thread',
-                    'help_block' => 'form.help_hide_thread',
+                    'sonata_help' => 'form.help_hide_thread',
                 )),
                 array('omit_script', 'checkbox', array(
                     'required' => false,
                     'label' => 'form.label_omit_script',
-                    'help_block' => 'form.help_omit_script',
+                    'sonata_help' => 'form.help_omit_script',
                 )),
                 array('align', 'choice', array(
                     'required' => false,
@@ -129,7 +129,7 @@ class TwitterEmbedTweetBlockService extends BaseTwitterButtonBlockService
                 array('related', 'text', array(
                     'required' => false,
                     'label' => 'form.label_related',
-                    'help_block' => 'form.help_related',
+                    'sonata_help' => 'form.help_related',
                 )),
                 array('lang', 'choice', array(
                     'required' => true,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #185

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Pass the right option for showing form help in twitter embedded block
```
