### PR TITLE
allow twig ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/options-resolver": "^2.3 || ^3.0",
         "sonata-project/exporter": "^1.2.2",
         "sonata-project/block-bundle": "^3.2",
-        "twig/twig": "^1.12"
+        "twig/twig": "^1.12 || ^2.0"
     },
     "require-dev": {
         "guzzle/guzzle": "3.*",


### PR DESCRIPTION
I am targeting this branch, because this should be backwards compatible.

## Changelog

```markdown
### Changed
- Change twig/twig composer.requirement to allow `^2.0`
```
## Subject

Will allow twig 2.0 when using the SonataSeoBundle