### PR TITLE
add twig filter for content-spinning

### DIFF
--- a/Resources/doc/reference/twig_helpers.rst
+++ b/Resources/doc/reference/twig_helpers.rst
@@ -86,3 +86,21 @@ This will render oEmbed links as follows:
 .. code-block:: html
 
     <link rel="alternate" type="application/json+oembed" href="http://flickr.com/services/oembed?url=http%3A%2F%2Fflickr.com%2Fphotos%2Fbees%2F2362225867%2F&format=json" title="Bacon Lollys oEmbed Profile" />
+
+Content spinning
+^^^^^^^^^^^^^^^^
+
+`Content spinning <https://www.wikiwand.com/en/Article_spinning#/Automatic_spinning>`_, is a search engine optimization (SEO) technique. Content spinning makes it possible to publish dozens of texts from a written text rather than spend time writing these dozens of texts.
+From the same text it is thus possible to publish a content several times without the search engines detecting it as duplicate content.
+
+`You could see more about Content spinning, here <https://www.wikiwand.com/en/Article_spinning#/Automatic_spinning>`_
+
+.. code-block:: jinja
+
+    {{ sonata_seo_content_spinner("{Beerpong|Tea} is {great|good|excellent} for {health|life}.") }}
+
+This will render content spinning as follows:
+
+.. code-block:: html
+
+    Tea is good for health.

--- a/Tests/Twig/Extension/SeoExtensionTest.php
+++ b/Tests/Twig/Extension/SeoExtensionTest.php
@@ -113,6 +113,18 @@ class SeoExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("<link rel=\"alternate\" href=\"http://example.com/\" hreflang=\"x-default\"/>\n", $extension->getLangAlternates());
     }
 
+    public function testContentSpinnerFilter()
+    {
+        $page = $this->createMock('Sonata\SeoBundle\Seo\SeoPageInterface');
+
+        $extension = new SeoExtension($page, 'UTF-8');
+        $text = '{Beerpong|Tea} is {great|good|excellent} for {health|life}.';
+
+        $this->assertContains('is', $extension->contentSpinningFilter($text));
+        $this->assertContains('for', $extension->contentSpinningFilter($text));
+        $this->assertRegexp('/great|good|excellent/', $extension->contentSpinningFilter($text));
+    }
+
     public function testOEmbedLinks()
     {
         $page = $this->getMock('Sonata\SeoBundle\Seo\SeoPageInterface');

--- a/Twig/Extension/SeoExtension.php
+++ b/Twig/Extension/SeoExtension.php
@@ -48,6 +48,7 @@ class SeoExtension extends \Twig_Extension
             new \Twig_SimpleFunction('sonata_seo_link_canonical', array($this, 'getLinkCanonical'), array('is_safe' => array('html'))),
             new \Twig_SimpleFunction('sonata_seo_lang_alternates', array($this, 'getLangAlternates'), array('is_safe' => array('html'))),
             new \Twig_SimpleFunction('sonata_seo_oembed_links', array($this, 'getOembedLinks'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('sonata_seo_content_spinner', array($this, 'contentSpinningFilter')),
         );
     }
 
@@ -215,6 +216,34 @@ class SeoExtension extends \Twig_Extension
         }
 
         return $html;
+    }
+
+    /**
+     * @param string $string
+     *
+     * @return string
+     */
+    public function contentSpinningFilter($string)
+    {
+        return preg_replace_callback(
+            '/\{(((?>[^\{\}]+)|(?R))*)\}/x',
+            array($this, 'replace'),
+            $string
+        );
+    }
+
+    /**
+     * Replace.
+     *
+     * @param string $text
+     *
+     * @return string
+     */
+    private function replace($text)
+    {
+        $parts = explode('|', $this->contentSpinningFilter($text[1]));
+
+        return $parts[array_rand($parts)];
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the SonataSeoBundle missing an extension to use content spinning in SEO.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added twig filter for content spinning
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests
- [x] Update the documentation

## Subject

<!-- Describe your Pull Request content here -->
