### PR TITLE
use createMock instead of deprecated getMock()

### DIFF
--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -12,10 +12,11 @@
 namespace Sonata\SeoBundle\Tests\DependencyInjection;
 
 use Sonata\SeoBundle\DependencyInjection\Configuration;
+use Sonata\SeoBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Yaml\Yaml;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends PHPUnit_Framework_TestCase
 {
     public function testDefaultConfiguration()
     {

--- a/Tests/DependencyInjection/SonataSeoExtensionTest.php
+++ b/Tests/DependencyInjection/SonataSeoExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\SeoBundle\Tests\DependencyInjection;
 
 use Sonata\SeoBundle\DependencyInjection\SonataSeoExtension;
+use Sonata\SeoBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -19,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  *
  * @author Vincent Tommasi <tommasi.v@gmail.com>
  */
-class SonataSeoExtensionTest extends \PHPUnit_Framework_TestCase
+class SonataSeoExtensionTest extends PHPUnit_Framework_TestCase
 {
     /**
      * Tests the loading of blocks.xml file.

--- a/Tests/Helpers/PHPUnit_Framework_TestCase.php
+++ b/Tests/Helpers/PHPUnit_Framework_TestCase.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\SeoBundle\Tests\Helpers;
+
+/**
+ * This is helpers class for supporting old and new PHPUnit versions.
+ *
+ * @todo NEXT_MAJOR: Remove this class when dropping support for < PHPUnit 5.4.
+ *
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+class PHPUnit_Framework_TestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function expectException($exception, $message = '', $code = null)
+    {
+        if (is_callable('parent::expectException')) {
+            parent::expectException($exception);
+
+            if ($message !== '') {
+                parent::expectExceptionMessage($message);
+            }
+
+            if ($code !== null) {
+                parent::expectExceptionCode($code);
+            }
+        }
+
+        return parent::setExpectedException($exception, $message, $code);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createMock($originalClassName)
+    {
+        if (is_callable('parent::createMock')) {
+            return parent::createMock($originalClassName);
+        }
+
+        return parent::getMockBuilder($originalClassName)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->getMock();
+    }
+}

--- a/Tests/Seo/SeoPageTest.php
+++ b/Tests/Seo/SeoPageTest.php
@@ -12,8 +12,9 @@
 namespace Sonata\SeoBundle\Tests\Seo;
 
 use Sonata\SeoBundle\Seo\SeoPage;
+use Sonata\SeoBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class SeoPageTest extends \PHPUnit_Framework_TestCase
+class SeoPageTest extends PHPUnit_Framework_TestCase
 {
     public function testAddMeta()
     {

--- a/Tests/Twig/Extension/SeoExtensionTest.php
+++ b/Tests/Twig/Extension/SeoExtensionTest.php
@@ -11,13 +11,14 @@
 
 namespace Sonata\SeoBundle\Tests\Request;
 
+use Sonata\SeoBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\SeoBundle\Twig\Extension\SeoExtension;
 
-class SeoExtensionTest extends \PHPUnit_Framework_TestCase
+class SeoExtensionTest extends PHPUnit_Framework_TestCase
 {
     public function testHtmlAttributes()
     {
-        $page = $this->getMock('Sonata\SeoBundle\Seo\SeoPageInterface');
+        $page = $this->createMock('Sonata\SeoBundle\Seo\SeoPageInterface');
         $page->expects($this->once())->method('getHtmlAttributes')->will($this->returnValue(array(
             'xmlns' => 'http://www.w3.org/1999/xhtml',
             'xmlns:og' => 'http://opengraphprotocol.org/schema/',
@@ -30,7 +31,7 @@ class SeoExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testHeadAttributes()
     {
-        $page = $this->getMock('Sonata\SeoBundle\Seo\SeoPageInterface');
+        $page = $this->createMock('Sonata\SeoBundle\Seo\SeoPageInterface');
         $page->expects($this->once())->method('getHeadAttributes')->will($this->returnValue(array()));
 
         $extension = new SeoExtension($page, 'UTF-8');
@@ -40,7 +41,7 @@ class SeoExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testTitle()
     {
-        $page = $this->getMock('Sonata\SeoBundle\Seo\SeoPageInterface');
+        $page = $this->createMock('Sonata\SeoBundle\Seo\SeoPageInterface');
         $page->expects($this->once())->method('getTitle')->will($this->returnValue('<b>foo bar</b>'));
 
         $extension = new SeoExtension($page, 'UTF-8');
@@ -50,7 +51,7 @@ class SeoExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testEncoding()
     {
-        $page = $this->getMock('Sonata\SeoBundle\Seo\SeoPageInterface');
+        $page = $this->createMock('Sonata\SeoBundle\Seo\SeoPageInterface');
         $page->expects($this->once())->method('getTitle')->will($this->returnValue('pięć głów zatkniętych na pal'));
         $page->expects($this->once())->method('getMetas')->will($this->returnValue(array(
             'http-equiv' => array(),
@@ -69,7 +70,7 @@ class SeoExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testMetadatas()
     {
-        $page = $this->getMock('Sonata\SeoBundle\Seo\SeoPageInterface');
+        $page = $this->createMock('Sonata\SeoBundle\Seo\SeoPageInterface');
         $page->expects($this->once())->method('getMetas')->will($this->returnValue(array(
             'http-equiv' => array(),
             'name' => array('foo' => array('bar "\'"', array())),
@@ -85,7 +86,7 @@ class SeoExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testName()
     {
-        $page = $this->getMock('Sonata\SeoBundle\Seo\SeoPageInterface');
+        $page = $this->createMock('Sonata\SeoBundle\Seo\SeoPageInterface');
         $extension = new SeoExtension($page, 'UTF-8');
 
         $this->assertEquals('sonata_seo', $extension->getName());
@@ -93,7 +94,7 @@ class SeoExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testLinkCanonical()
     {
-        $page = $this->getMock('Sonata\SeoBundle\Seo\SeoPageInterface');
+        $page = $this->createMock('Sonata\SeoBundle\Seo\SeoPageInterface');
         $page->expects($this->any())->method('getLinkCanonical')->will($this->returnValue('http://example.com'));
 
         $extension = new SeoExtension($page, 'UTF-8');
@@ -103,7 +104,7 @@ class SeoExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testLangAlternates()
     {
-        $page = $this->getMock('Sonata\SeoBundle\Seo\SeoPageInterface');
+        $page = $this->createMock('Sonata\SeoBundle\Seo\SeoPageInterface');
         $page->expects($this->once())->method('getLangAlternates')->will($this->returnValue(array(
                     'http://example.com/' => 'x-default',
                 )));
@@ -115,7 +116,7 @@ class SeoExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testOEmbedLinks()
     {
-        $page = $this->getMock('Sonata\SeoBundle\Seo\SeoPageInterface');
+        $page = $this->createMock('Sonata\SeoBundle\Seo\SeoPageInterface');
         $page->expects($this->once())->method('getOembedLinks')->will($this->returnValue(array(
             'Foo' => 'http://example.com/',
         )));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.