### PR TITLE
Fix for Twig 2

### DIFF
--- a/Resources/views/Block/breadcrumb.html.twig
+++ b/Resources/views/Block/breadcrumb.html.twig
@@ -15,7 +15,7 @@ file that was distributed with this source code.
     {% set translation_domain = item.getExtra('translation_domain', 'SonataSeoBundle') %}
     {% if options.allow_safe_labels and item.extra('safe_label', false) %}
         {{- item.label|raw -}}
-    {% elseif translation_domain is sameas(false) %}
+    {% elseif translation_domain is same as(false) %}
         {{- item.label -}}
     {% else %}
         {{- item.label|trans(item.getExtra('translation_params', {}), translation_domain) -}}

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/options-resolver": "^2.3 || ^3.0",
         "sonata-project/exporter": "^1.2.2",
         "sonata-project/block-bundle": "^3.2",
-        "twig/twig": "^1.12 || ^2.0"
+        "twig/twig": "^1.14.2 || ^2.0"
     },
     "require-dev": {
         "guzzle/guzzle": "3.*",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because branch 2.x supports Twig 2.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
 - `SonataSeoBundle/Resources/views/Block/breadcrumb.html.twig` changed "sameas" in "same as"

```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->


## Subject

<!-- Describe your Pull Request content here -->

In twig 2 "sameas" bacames "same as" ( https://twig.sensiolabs.org/doc/2.x/tests/sameas.html)

"same as" works also in in Twig 1 because it is an alias of "sameas" (https://twig.sensiolabs.org/doc/1.x/tests/sameas.html)