### PR TITLE
move block-bundle back to require-dev

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,6 +1,12 @@
 UPGRADE 2.x
 ===========
 
+UPGRADE FROM 2.2.0 to 2.2.1
+===========================
+
+`sonata-project/block-bundle` is not required anymore. If you want to use seo friendly blocks,
+you should require it on your own by calling `composer require sonata-project/block-bundle`.
+
 UPGRADE FROM 2.0 to 2.1
 =======================
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "symfony/framework-bundle": "^2.3 || ^3.0",
         "symfony/options-resolver": "^2.3 || ^3.0",
         "sonata-project/exporter": "^1.2.2",
-        "sonata-project/block-bundle": "^3.2",
         "twig/twig": "^1.14.2 || ^2.0"
     },
     "require-dev": {
@@ -30,6 +29,7 @@
         "symfony/finder": "^2.3 || ^3.0",
         "sonata-project/admin-bundle": "^3.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
+        "sonata-project/block-bundle": "^3.2",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0"
     },
     "suggest": {


### PR DESCRIPTION
I am targeting this branch, because  the optional dependency was added here.

## Changelog

```markdown

### Changed

- moved `sonata-project/block-bundle` back to require-dev
```
# Subject

When block-bundle is required it forces me also to set a configuration for `sonata_block.default_context`. As the block usage is optional we should move this requiredment back to require-dev