### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,18 +17,18 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
-        "symfony/framework-bundle": "^2.3 || ^3.0",
-        "symfony/options-resolver": "^2.3 || ^3.0",
+        "php": "^7.1",
+        "symfony/framework-bundle": "^2.8 || ^3.0",
+        "symfony/options-resolver": "^2.8 || ^3.0",
         "sonata-project/exporter": "^1.2.2",
         "twig/twig": "^1.14.2 || ^2.0"
     },
     "require-dev": {
         "guzzle/guzzle": "3.*",
-        "symfony/console": "^2.3 || ^3.0",
-        "symfony/finder": "^2.3 || ^3.0",
+        "symfony/console": "^2.8 || ^3.0",
+        "symfony/finder": "^2.8 || ^3.0",
         "sonata-project/admin-bundle": "^3.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0",
+        "symfony/phpunit-bridge": "^3.3",
         "sonata-project/block-bundle": "^3.2",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0"
     },

--- a/src/DependencyInjection/SonataSeoExtension.php
+++ b/src/DependencyInjection/SonataSeoExtension.php
@@ -46,23 +46,9 @@ class SonataSeoExtension extends Extension
 
         $this->configureSeoPage($config['page'], $container);
         $this->configureSitemap($config['sitemap'], $container);
-        $this->configureClassesToCompile();
 
         $container->getDefinition('sonata.seo.twig.extension')
             ->replaceArgument(1, $config['encoding']);
-    }
-
-    /**
-     * Add class to compile.
-     */
-    public function configureClassesToCompile()
-    {
-        $this->addClassesToCompile([
-            'Sonata\\SeoBundle\\Seo\\SeoPage',
-            'Sonata\\SeoBundle\\Seo\\SeoPageInterface',
-            'Sonata\\SeoBundle\\Sitemap\\SourceManager',
-            'Sonata\\SeoBundle\\Twig\\Extension\\SeoExtension',
-        ]);
     }
 
     /**


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Removed
- Support for old versions of PHP and Symfony.
```
