### PR TITLE
Removed symfony BC layer for old symfony versions

### DIFF
--- a/src/Block/Social/EmailShareButtonBlockService.php
+++ b/src/Block/Social/EmailShareButtonBlockService.php
@@ -15,7 +15,9 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -43,13 +45,13 @@ class EmailShareButtonBlockService extends AbstractAdminBlockService
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['subject', 'text', [
+                ['subject', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_subject',
                 ]],
-                ['body', 'text', [
+                ['body', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_body',
                 ]],

--- a/src/Block/Social/FacebookLikeBoxBlockService.php
+++ b/src/Block/Social/FacebookLikeBoxBlockService.php
@@ -13,7 +13,12 @@ namespace Sonata\SeoBundle\Block\Social;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -48,38 +53,38 @@ class FacebookLikeBoxBlockService extends BaseFacebookSocialPluginsBlockService
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['url', 'url', [
+                ['url', UrlType::class, [
                     'required' => false,
                     'label' => 'form.label_url',
                 ]],
-                ['width', 'integer', [
+                ['width', IntegerType::class, [
                     'required' => false,
                     'label' => 'form.label_width',
                 ]],
-                ['height', 'integer', [
+                ['height', IntegerType::class, [
                     'required' => false,
                     'label' => 'form.label_height',
                 ]],
-                ['colorscheme', 'choice', [
+                ['colorscheme', ChoiceType::class, [
                     'required' => true,
                     'choices' => $this->colorschemeList,
                     'label' => 'form.label_colorscheme',
                 ]],
-                ['show_faces', 'checkbox', [
+                ['show_faces', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_show_faces',
                 ]],
-                ['show_header', 'checkbox', [
+                ['show_header', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_show_header',
                 ]],
-                ['show_posts', 'checkbox', [
+                ['show_posts', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_show_posts',
                 ]],
-                ['show_border', 'checkbox', [
+                ['show_border', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_show_border',
                 ]],

--- a/src/Block/Social/FacebookLikeButtonBlockService.php
+++ b/src/Block/Social/FacebookLikeButtonBlockService.php
@@ -13,7 +13,12 @@ namespace Sonata\SeoBundle\Block\Social;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -65,35 +70,35 @@ class FacebookLikeButtonBlockService extends BaseFacebookSocialPluginsBlockServi
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['url', 'url', [
+                ['url', UrlType::class, [
                     'required' => false,
                     'label' => 'form.label_url',
                 ]],
-                ['width', 'integer', [
+                ['width', IntegerType::class, [
                     'required' => false,
                     'label' => 'form.label_width',
                 ]],
-                ['show_faces', 'checkbox', [
+                ['show_faces', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_show_faces',
                 ]],
-                ['share', 'checkbox', [
+                ['share', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_share',
                 ]],
-                ['layout', 'choice', [
+                ['layout', ChoiceType::class, [
                     'required' => true,
                     'choices' => $this->layoutList,
                     'label' => 'form.label_layout',
                 ]],
-                ['colorscheme', 'choice', [
+                ['colorscheme', ChoiceType::class, [
                     'required' => true,
                     'choices' => $this->colorschemeList,
                     'label' => 'form.label_colorscheme',
                 ]],
-                ['action', 'choice', [
+                ['action', ChoiceType::class, [
                     'required' => true,
                     'choices' => $this->actionTypes,
                     'label' => 'form.label_action',

--- a/src/Block/Social/FacebookSendButtonBlockService.php
+++ b/src/Block/Social/FacebookSendButtonBlockService.php
@@ -13,7 +13,11 @@ namespace Sonata\SeoBundle\Block\Social;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -44,21 +48,21 @@ class FacebookSendButtonBlockService extends BaseFacebookSocialPluginsBlockServi
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['url', 'url', [
+                ['url', UrlType::class, [
                     'required' => false,
                     'label' => 'form.label_url',
                 ]],
-                ['width', 'integer', [
+                ['width', IntegerType::class, [
                     'required' => false,
                     'label' => 'form.label_width',
                 ]],
-                ['height', 'integer', [
+                ['height', IntegerType::class, [
                     'required' => false,
                     'label' => 'form.label_height',
                 ]],
-                ['colorscheme', 'choice', [
+                ['colorscheme', ChoiceType::class, [
                     'required' => true,
                     'choices' => $this->colorschemeList,
                     'label' => 'form.label_colorscheme',

--- a/src/Block/Social/FacebookShareButtonBlockService.php
+++ b/src/Block/Social/FacebookShareButtonBlockService.php
@@ -13,7 +13,11 @@ namespace Sonata\SeoBundle\Block\Social;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -55,17 +59,17 @@ class FacebookShareButtonBlockService extends BaseFacebookSocialPluginsBlockServ
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['url', 'url', [
+                ['url', UrlType::class, [
                     'required' => false,
                     'label' => 'form.label_url',
                 ]],
-                ['width', 'integer', [
+                ['width', IntegerType::class, [
                     'required' => false,
                     'label' => 'form.label_width',
                 ]],
-                ['layout', 'choice', [
+                ['layout', ChoiceType::class, [
                     'required' => true,
                     'choices' => $this->layoutList,
                     'label' => 'form.label_layout',

--- a/src/Block/Social/PinterestPinButtonBlockService.php
+++ b/src/Block/Social/PinterestPinButtonBlockService.php
@@ -15,7 +15,12 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -48,25 +53,25 @@ class PinterestPinButtonBlockService extends AbstractAdminBlockService
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['url', 'url', [
+                ['url', UrlType::class, [
                     'required' => false,
                     'label' => 'form.label_url',
                 ]],
-                ['image', 'text', [
+                ['image', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_image',
                 ]],
-                ['description', 'text', [
+                ['description', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_description',
                 ]],
-                ['size', 'integer', [
+                ['size', IntegerType::class, [
                     'required' => false,
                     'label' => 'form.label_size',
                 ]],
-                ['shape', 'choice', [
+                ['shape', ChoiceType::class, [
                     'required' => false,
                     'choices' => [
                         'rectangular' => 'form.label_shape_rectangular',

--- a/src/Block/Social/TwitterEmbedTweetBlockService.php
+++ b/src/Block/Social/TwitterEmbedTweetBlockService.php
@@ -15,7 +15,13 @@ use Guzzle\Http\Exception\CurlException;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -89,34 +95,34 @@ class TwitterEmbedTweetBlockService extends BaseTwitterButtonBlockService
      */
     public function buildEditForm(FormMapper $form, BlockInterface $block)
     {
-        $form->add('settings', 'sonata_type_immutable_array', [
+        $form->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['tweet', 'textarea', [
+                ['tweet', TextareaType::class, [
                     'required' => true,
                     'label' => 'form.label_tweet',
                     'sonata_help' => 'form.help_tweet',
                 ]],
-                ['maxwidth', 'integer', [
+                ['maxwidth', IntegerType::class, [
                     'required' => false,
                     'label' => 'form.label_maxwidth',
                     'sonata_help' => 'form.help_maxwidth',
                 ]],
-                ['hide_media', 'checkbox', [
+                ['hide_media', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_hide_media',
                     'sonata_help' => 'form.help_hide_media',
                 ]],
-                ['hide_thread', 'checkbox', [
+                ['hide_thread', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_hide_thread',
                     'sonata_help' => 'form.help_hide_thread',
                 ]],
-                ['omit_script', 'checkbox', [
+                ['omit_script', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_omit_script',
                     'sonata_help' => 'form.help_omit_script',
                 ]],
-                ['align', 'choice', [
+                ['align', ChoiceType::class, [
                     'required' => false,
                     'choices' => [
                         'left' => 'form.label_align_left',
@@ -126,12 +132,12 @@ class TwitterEmbedTweetBlockService extends BaseTwitterButtonBlockService
                     ],
                     'label' => 'form.label_align',
                 ]],
-                ['related', 'text', [
+                ['related', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_related',
                     'sonata_help' => 'form.help_related',
                 ]],
-                ['lang', 'choice', [
+                ['lang', ChoiceType::class, [
                     'required' => true,
                     'choices' => $this->languageList,
                     'label' => 'form.label_lang',

--- a/src/Block/Social/TwitterFollowButtonBlockService.php
+++ b/src/Block/Social/TwitterFollowButtonBlockService.php
@@ -13,7 +13,11 @@ namespace Sonata\SeoBundle\Block\Social;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -45,25 +49,25 @@ class TwitterFollowButtonBlockService extends BaseTwitterButtonBlockService
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['user', 'text', [
+                ['user', TextType::class, [
                     'required' => true,
                     'label' => 'form.label_user',
                 ]],
-                ['show_username', 'checkbox', [
+                ['show_username', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_show_username',
                 ]],
-                ['large_button', 'checkbox', [
+                ['large_button', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_large_button',
                 ]],
-                ['opt_out', 'checkbox', [
+                ['opt_out', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_opt_out',
                 ]],
-                ['language', 'choice', [
+                ['language', ChoiceType::class, [
                     'required' => true,
                     'choices' => $this->languageList,
                     'label' => 'form.label_language',

--- a/src/Block/Social/TwitterHashtagButtonBlockService.php
+++ b/src/Block/Social/TwitterHashtagButtonBlockService.php
@@ -13,7 +13,12 @@ namespace Sonata\SeoBundle\Block\Social;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -47,33 +52,33 @@ class TwitterHashtagButtonBlockService extends BaseTwitterButtonBlockService
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['hashtag', 'text', [
+                ['hashtag', TextType::class, [
                     'required' => true,
                     'label' => 'form.label_hashtag',
                 ]],
-                ['text', 'text', [
+                ['text', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_text',
                 ]],
-                ['recommend', 'text', [
+                ['recommend', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_recommend',
                 ]],
-                ['url', 'url', [
+                ['url', UrlType::class, [
                     'required' => false,
                     'label' => 'form.label_url',
                 ]],
-                ['large_button', 'checkbox', [
+                ['large_button', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_large_button',
                 ]],
-                ['opt_out', 'checkbox', [
+                ['opt_out', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_opt_out',
                 ]],
-                ['language', 'choice', [
+                ['language', ChoiceType::class, [
                     'required' => true,
                     'choices' => $this->languageList,
                     'label' => 'form.label_language',

--- a/src/Block/Social/TwitterMentionButtonBlockService.php
+++ b/src/Block/Social/TwitterMentionButtonBlockService.php
@@ -13,7 +13,11 @@ namespace Sonata\SeoBundle\Block\Social;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -46,29 +50,29 @@ class TwitterMentionButtonBlockService extends BaseTwitterButtonBlockService
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['user', 'text', [
+                ['user', TextType::class, [
                     'required' => true,
                     'label' => 'form.label_user',
                 ]],
-                ['text', 'text', [
+                ['text', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_text',
                 ]],
-                ['recommend', 'text', [
+                ['recommend', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_recommend',
                 ]],
-                ['large_button', 'checkbox', [
+                ['large_button', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_large_button',
                 ]],
-                ['opt_out', 'checkbox', [
+                ['opt_out', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_opt_out',
                 ]],
-                ['language', 'choice', [
+                ['language', ChoiceType::class, [
                     'required' => true,
                     'choices' => $this->languageList,
                     'label' => 'form.label_language',

--- a/src/Block/Social/TwitterShareButtonBlockService.php
+++ b/src/Block/Social/TwitterShareButtonBlockService.php
@@ -13,7 +13,12 @@ namespace Sonata\SeoBundle\Block\Social;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -49,41 +54,41 @@ class TwitterShareButtonBlockService extends BaseTwitterButtonBlockService
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['url', 'url', [
+                ['url', UrlType::class, [
                     'required' => false,
                     'label' => 'form.label_url',
                 ]],
-                ['text', 'text', [
+                ['text', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_text',
                 ]],
-                ['show_count', 'checkbox', [
+                ['show_count', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_show_count',
                 ]],
-                ['via', 'text', [
+                ['via', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_via',
                 ]],
-                ['recommend', 'text', [
+                ['recommend', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_recommend',
                 ]],
-                ['hashtag', 'text', [
+                ['hashtag', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_hashtag',
                 ]],
-                ['large_button', 'checkbox', [
+                ['large_button', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_large_button',
                 ]],
-                ['opt_out', 'checkbox', [
+                ['opt_out', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_opt_out',
                 ]],
-                ['language', 'choice', [
+                ['language', ChoiceType::class, [
                     'required' => true,
                     'choices' => $this->languageList,
                     'label' => 'form.label_language',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
 - Removed BC layer for old symfony versions
```
