### PR TITLE
Drop old versions of sf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,19 +18,19 @@
     ],
     "require": {
         "php": "^7.1",
+        "sonata-project/exporter": "^1.2.2",
         "symfony/framework-bundle": "^2.8 || ^3.0",
         "symfony/options-resolver": "^2.8 || ^3.0",
-        "sonata-project/exporter": "^1.2.2",
         "twig/twig": "^1.14.2 || ^2.0"
     },
     "require-dev": {
         "guzzle/guzzle": "3.*",
+        "sllh/php-cs-fixer-styleci-bridge": "^2.0",
+        "sonata-project/admin-bundle": "^3.0",
+        "sonata-project/block-bundle": "^3.2",
         "symfony/console": "^2.8 || ^3.0",
         "symfony/finder": "^2.8 || ^3.0",
-        "sonata-project/admin-bundle": "^3.0",
-        "symfony/phpunit-bridge": "^3.3",
-        "sonata-project/block-bundle": "^3.2",
-        "sllh/php-cs-fixer-styleci-bridge": "^2.0"
+        "symfony/phpunit-bridge": "^3.3"
     },
     "suggest": {
         "guzzle/guzzle": "3.*",
@@ -41,7 +41,10 @@
     },
     "autoload-dev": {
         "psr-4": { "Sonata\\SeoBundle\\Tests\\": "tests/" }
-     },
+    },
+    "config": {
+        "sort-packages": true
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     "require": {
         "php": "^7.1",
         "sonata-project/exporter": "^1.2.2",
-        "symfony/framework-bundle": "^2.8 || ^3.0",
-        "symfony/options-resolver": "^2.8 || ^3.0",
+        "symfony/framework-bundle": "^2.8 || ^3.2",
+        "symfony/options-resolver": "^2.8 || ^3.2",
         "twig/twig": "^1.14.2 || ^2.0"
     },
     "require-dev": {
@@ -28,8 +28,8 @@
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/admin-bundle": "^3.0",
         "sonata-project/block-bundle": "^3.2",
-        "symfony/console": "^2.8 || ^3.0",
-        "symfony/finder": "^2.8 || ^3.0",
+        "symfony/console": "^2.8 || ^3.2",
+        "symfony/finder": "^2.8 || ^3.2",
         "symfony/phpunit-bridge": "^3.3"
     },
     "suggest": {


### PR DESCRIPTION
I am targeting this branch, because this is BC.

There is a separate commit for sort composer packages, because it is applied to all bundles, except this (for the moment is the only I saw without it)

## Changelog

```markdown
### Removed
- Support for `^3.0` and `^3.1` versions of `framework-bundle` and `options-resolver`.
```