### PR TITLE
do not use deprecated array for block menu service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "guzzle/guzzle": "3.*",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/admin-bundle": "^3.0",
-        "sonata-project/block-bundle": "^3.2",
+        "sonata-project/block-bundle": "^3.7",
         "symfony/console": "^2.8 || ^3.2",
         "symfony/finder": "^2.8 || ^3.2",
         "symfony/phpunit-bridge": "^3.3"

--- a/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
+++ b/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
@@ -45,7 +45,7 @@ abstract class BaseBreadcrumbMenuBlockService extends MenuBlockService
      */
     public function __construct($context, $name, EngineInterface $templating, MenuProviderInterface $menuProvider, FactoryInterface $factory)
     {
-        parent::__construct($name, $templating, $menuProvider, []);
+        parent::__construct($name, $templating, $menuProvider);
 
         $this->context = $context;
         $this->factory = $factory;


### PR DESCRIPTION
I am targeting this branch, because this is deprecated on this branch.

Closes #238

## Changelog

```markdown
### Changed
- do not use deprecated array for block menu service
```

## Subject

See #238 
