### PR TITLE
Created AbstractBreadcrumbMenuService class

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,6 +1,19 @@
 UPGRADE 2.x
 ===========
 
+UPGRADE FROM 2.3 to 2.x
+=======================
+
+### Deprecated `BaseBreadcrumbMenuBlockService` class
+
+The class `Sonata\SeoBundle\Block\Breadcrumb\BaseBreadcrumbMenuBlockService` is deprecated in favor of 
+`Sonata\SeoBundle\Block\Breadcrumb\AbstractBreadcrumbMenuService`.
+With these changes the context is removed from the block and will be bound through the `sonata.breadcrumb` tag:
+
+```xml
+    <tag name="sonata.breadcrumb" context="my_custom_context" />
+```
+
 UPGRADE FROM 2.2 to 2.3
 =======================
 

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,9 @@
         "symfony/phpunit-bridge": "^4.0",
         "symfony/yaml": "^2.8 || ^3.2 || ^4.0"
     },
+    "conflict": {
+        "sonata-project/block-bundle": "<3.7"
+    },
     "suggest": {
         "guzzle/guzzle": "3.*",
         "knplabs/knp-menu-bundle": "Used by the BreadcrumbMenuBuilder"

--- a/docs/reference/breadcrumb.rst
+++ b/docs/reference/breadcrumb.rst
@@ -44,9 +44,7 @@ First, you need to create a BlockService to handle your breadcrumbs. You can ext
 
     <service id="acme.bundle.block.breadcrumb" class="Acme\Bundle\Block\MyCustomBreadcrumbBlockService">
         <tag name="sonata.block"/>
-        <tag name="sonata.breadcrumb"/>
-
-        <argument>my_custom_context</argument>
+        <tag name="sonata.breadcrumb" context="my_custom_context" />
         <argument>acme.bundle.block.breadcrumb</argument>
         <argument type="service" id="templating" />
         <argument type="service" id="knp_menu.menu_provider" />

--- a/src/Block/Breadcrumb/AbstractBreadcrumbMenuService.php
+++ b/src/Block/Breadcrumb/AbstractBreadcrumbMenuService.php
@@ -1,0 +1,194 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\SeoBundle\Block\Breadcrumb;
+
+use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
+use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Abstract class for breadcrumb menu services.
+ *
+ * @author Sylvain Deloux <sylvain.deloux@ekino.com>
+ * @author Christian Gripp <mail@core23.de>
+ */
+abstract class AbstractBreadcrumbMenuService extends AbstractBlockService
+{
+    /**
+     * @var FactoryInterface
+     */
+    private $factory;
+
+    /**
+     * @param string           $name
+     */
+    public function __construct($name, EngineInterface $templating, FactoryInterface $factory)
+    {
+        parent::__construct($name, $templating);
+
+        $this->factory = $factory;
+    }
+
+    public function execute(BlockContextInterface $blockContext, Response $response = null)
+    {
+        $responseSettings = [
+            'menu' => $this->getMenu($blockContext),
+            'menu_options' => $this->getMenuOptions($blockContext->getSettings()),
+            'block' => $blockContext->getBlock(),
+            'context' => $blockContext,
+        ];
+
+        if ('private' === $blockContext->getSetting('cache_policy')) {
+            return $this->renderPrivateResponse($blockContext->getTemplate(), $responseSettings, $response);
+        }
+
+        return $this->renderResponse($blockContext->getTemplate(), $responseSettings, $response);
+    }
+
+    public function buildEditForm(FormMapper $form, BlockInterface $block)
+    {
+        $form->add('settings', ImmutableArrayType::class, [
+            'keys' => $this->getFormSettingsKeys(),
+        ]);
+    }
+
+    public function getBlockMetadata($code = null)
+    {
+        return new Metadata($this->getName(), (null !== $code ? $code : $this->getName()), false, 'SonataBlockBundle', [
+            'class' => 'fa fa-bars',
+        ]);
+    }
+
+    public function configureSettings(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'title' => $this->getName(),
+            'cache_policy' => 'public',
+            'template' => '@SonataBlock/Block/block_core_menu.html.twig',
+            'menu_name' => '',
+            'safe_labels' => false,
+            'current_class' => 'active',
+            'first_class' => false,
+            'last_class' => false,
+            'current_uri' => null,
+            'menu_class' => 'list-group',
+            'children_class' => 'list-group-item',
+            'menu_template' => '@SonataSeo/Block/breadcrumb.html.twig',
+            'include_homepage_link' => true,
+            'context' => false,
+        ]);
+    }
+
+    /**
+     * @return array
+     */
+    protected function getFormSettingsKeys()
+    {
+        return [
+            ['title', TextType::class, ['required' => false]],
+            ['cache_policy', ChoiceType::class, ['choices' => ['public', 'private']]],
+            ['safe_labels', CheckboxType::class, ['required' => false]],
+            ['current_class', TextType::class, ['required' => false]],
+            ['first_class', TextType::class, ['required' => false]],
+            ['last_class', TextType::class, ['required' => false]],
+            ['menu_class', TextType::class, ['required' => false]],
+            ['children_class', TextType::class, ['required' => false]],
+            ['menu_template', TextType::class, ['required' => false]],
+        ];
+    }
+
+    /**
+     * Gets the menu to render.
+     *
+     * @return ItemInterface|string
+     */
+    protected function getMenu(BlockContextInterface $blockContext)
+    {
+        return $this->getRootMenu($blockContext);
+    }
+
+    /**
+     * Replaces setting keys with knp menu item options keys.
+     *
+     * @return array
+     */
+    protected function getMenuOptions(array $settings)
+    {
+        $mapping = [
+            'current_class' => 'currentClass',
+            'first_class' => 'firstClass',
+            'last_class' => 'lastClass',
+            'safe_labels' => 'allow_safe_labels',
+            'menu_template' => 'template',
+        ];
+
+        $options = [];
+
+        foreach ($settings as $key => $value) {
+            if (array_key_exists($key, $mapping) && null !== $value) {
+                $options[$mapping[$key]] = $value;
+            }
+        }
+
+        return $options;
+    }
+
+    /**
+     * @return FactoryInterface
+     */
+    protected function getFactory()
+    {
+        return $this->factory;
+    }
+
+    /**
+     * Initialize breadcrumb menu.
+     *
+     * @return ItemInterface
+     */
+    protected function getRootMenu(BlockContextInterface $blockContext)
+    {
+        $settings = $blockContext->getSettings();
+        /*
+         * @todo : Use the router to get the homepage URI
+         */
+
+        $menu = $this->factory->createItem('breadcrumb');
+
+        $menu->setChildrenAttribute('class', 'breadcrumb');
+
+        if (method_exists($menu, 'setCurrentUri')) {
+            $menu->setCurrentUri($settings['current_uri']);
+        }
+
+        if (method_exists($menu, 'setCurrent')) {
+            $menu->setCurrent($settings['current_uri']);
+        }
+
+        if ($settings['include_homepage_link']) {
+            $menu->addChild('sonata_seo_homepage_breadcrumb', ['uri' => '/']);
+        }
+
+        return $menu;
+    }
+}

--- a/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
+++ b/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
@@ -12,29 +12,22 @@
 namespace Sonata\SeoBundle\Block\Breadcrumb;
 
 use Knp\Menu\FactoryInterface;
-use Knp\Menu\ItemInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
-use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\Service\MenuBlockService;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Abstract class for breadcrumb menu services.
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
+ *
+ * @deprecated since 3.x, to be removed with 4.0.
  */
-abstract class BaseBreadcrumbMenuBlockService extends MenuBlockService
+abstract class BaseBreadcrumbMenuBlockService extends AbstractBreadcrumbMenuService
 {
     /**
      * @var string
      */
     private $context;
-
-    /**
-     * @var FactoryInterface
-     */
-    private $factory;
 
     /**
      * @param string                $context
@@ -45,10 +38,15 @@ abstract class BaseBreadcrumbMenuBlockService extends MenuBlockService
      */
     public function __construct($context, $name, EngineInterface $templating, MenuProviderInterface $menuProvider, FactoryInterface $factory)
     {
-        parent::__construct($name, $templating, $menuProvider);
+        @trigger_error(
+            'The '.__CLASS__.' class is deprecated since 3.x, to be removed in 4.0. '.
+            'Use '.AbstractBreadcrumbMenuService::class.' instead.',
+            E_USER_DEPRECATED
+        );
+
+        parent::__construct($name, $templating, $factory);
 
         $this->context = $context;
-        $this->factory = $factory;
     }
 
     /**
@@ -64,36 +62,6 @@ abstract class BaseBreadcrumbMenuBlockService extends MenuBlockService
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return sprintf('Breadcrumb %s', $this->context);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function configureSettings(OptionsResolver $resolver)
-    {
-        parent::configureSettings($resolver);
-
-        $resolver->setDefaults([
-            'menu_template' => '@SonataSeo/Block/breadcrumb.html.twig',
-            'include_homepage_link' => true,
-            'context' => false,
-        ]);
-    }
-
-    /**
-     * @return FactoryInterface
-     */
-    protected function getFactory()
-    {
-        return $this->factory;
-    }
-
-    /**
      * @return string
      */
     protected function getContext()
@@ -102,35 +70,10 @@ abstract class BaseBreadcrumbMenuBlockService extends MenuBlockService
     }
 
     /**
-     * Initialize breadcrumb menu.
-     *
-     * @param BlockContextInterface $blockContext
-     *
-     * @return ItemInterface
+     * {@inheritdoc}
      */
-    protected function getRootMenu(BlockContextInterface $blockContext)
+    public function getName()
     {
-        $settings = $blockContext->getSettings();
-        /*
-         * @todo : Use the router to get the homepage URI
-         */
-
-        $menu = $this->factory->createItem('breadcrumb');
-
-        $menu->setChildrenAttribute('class', 'breadcrumb');
-
-        if (method_exists($menu, 'setCurrentUri')) {
-            $menu->setCurrentUri($settings['current_uri']);
-        }
-
-        if (method_exists($menu, 'setCurrent')) {
-            $menu->setCurrent($settings['current_uri']);
-        }
-
-        if ($settings['include_homepage_link']) {
-            $menu->addChild('sonata_seo_homepage_breadcrumb', ['uri' => '/']);
-        }
-
-        return $menu;
+        return sprintf('Breadcrumb %s', $this->getContext());
     }
 }

--- a/src/Block/Breadcrumb/HomepageBreadcrumbBlockService.php
+++ b/src/Block/Breadcrumb/HomepageBreadcrumbBlockService.php
@@ -11,14 +11,12 @@
 
 namespace Sonata\SeoBundle\Block\Breadcrumb;
 
-use Sonata\BlockBundle\Block\BlockContextInterface;
-
 /**
  * BlockService for homepage breadcrumb.
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
-class HomepageBreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
+class HomepageBreadcrumbBlockService extends AbstractBreadcrumbMenuService
 {
     /**
      * {@inheritdoc}
@@ -26,15 +24,5 @@ class HomepageBreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
     public function getName()
     {
         return 'Breadcrumb (Homepage)';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMenu(BlockContextInterface $blockContext)
-    {
-        $menu = $this->getRootMenu($blockContext);
-
-        return $menu;
     }
 }

--- a/src/DependencyInjection/Compiler/BreadcrumbBlockServicesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/BreadcrumbBlockServicesCompilerPass.php
@@ -25,8 +25,18 @@ class BreadcrumbBlockServicesCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        foreach ($container->findTaggedServiceIds('sonata.breadcrumb') as $id => $attributes) {
-            $container->getDefinition('sonata.seo.event.breadcrumb')->addMethodCall('addBlockService', [$id, new Reference($id)]);
+        $listener = $container->getDefinition('sonata.seo.event.breadcrumb');
+
+        foreach ($container->findTaggedServiceIds('sonata.breadcrumb') as $id => $tags) {
+            foreach ($tags as $tag) {
+                if (empty($tag['context'])) {
+                    continue;
+                }
+
+                $listener->addMethodCall('addBlockContext', [$tag['context'], $id]);
+            }
+
+            $listener->addMethodCall('addBlockService', [$id, new Reference($id)]);
         }
     }
 }

--- a/src/Event/BreadcrumbListener.php
+++ b/src/Event/BreadcrumbListener.php
@@ -28,14 +28,38 @@ class BreadcrumbListener
     protected $blockServices = [];
 
     /**
+     * @var array
+     */
+    protected $contextServices = [];
+
+    /**
      * Add a renderer to the status services list.
      *
      * @param string                $type
      * @param BlockServiceInterface $blockService
+     *
+     * @deprecated since 2.x, use BreadcrumbListener::addBlockContext instead
      */
     public function addBlockService($type, BlockServiceInterface $blockService)
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since 2.x, to be removed in 3.0. '.
+            'Use '.__NAMESPACE__.'::addBlockContext() instead.',
+            E_USER_DEPRECATED
+        );
+
         $this->blockServices[$type] = $blockService;
+    }
+
+    /**
+     * Binds a block service to a context.
+     *
+     * @param string $context
+     * @param string $serviceId
+     */
+    public function addBlockContext($context, $serviceId)
+    {
+        $this->contextServices[$context] = $serviceId;
     }
 
     /**
@@ -51,6 +75,18 @@ class BreadcrumbListener
             return;
         }
 
+        if (isset($this->contextServices[$context])) {
+            $block = new Block();
+            $block->setId(uniqid());
+            $block->setSettings($event->getSettings());
+            $block->setType($this->contextServices[$context]);
+
+            $event->addBlock($block);
+
+            return;
+        }
+
+        // NEXT_MAJOR: remove this block
         foreach ($this->blockServices as $type => $blockService) {
             if ($blockService->handleContext($context)) {
                 $block = new Block();

--- a/src/Resources/config/blocks.xml
+++ b/src/Resources/config/blocks.xml
@@ -85,10 +85,10 @@
         <!-- Pinterest buttons -->
         <!-- Breadcrumb -->
         <service id="sonata.seo.block.breadcrumb.homepage" class="%sonata.seo.block.breadcrumb.homepage.class%" public="true">
-            <tag name="sonata.breadcrumb"/>
+            <tag name="sonata.breadcrumb" context="homepage"/>
             <tag name="sonata.block"/>
-            <argument>homepage</argument>
             <argument>sonata.seo.block.breadcrumb.homepage</argument>
+            <argument>homepage</argument>
             <argument type="service" id="sonata.templating"/>
             <argument type="service" id="knp_menu.menu_provider"/>
             <argument type="service" id="knp_menu.factory"/>

--- a/tests/Block/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Block/Breadcrumb/BreadcrumbTest.php
@@ -11,10 +11,12 @@
 
 namespace Sonata\SeoBundle\Tests\Block\Breadcrumb;
 
+use Knp\Menu\FactoryInterface;
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
-use Sonata\SeoBundle\Block\Breadcrumb\BaseBreadcrumbMenuBlockService;
+use Sonata\SeoBundle\Block\Breadcrumb\AbstractBreadcrumbMenuService;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 
-class BreadcrumbMenuBlockService_Test extends BaseBreadcrumbMenuBlockService
+class BreadcrumbMenuBlockService_Test extends AbstractBreadcrumbMenuService
 {
 }
 
@@ -26,11 +28,9 @@ class BreadcrumbTest extends AbstractBlockServiceTestCase
     public function testBlockService()
     {
         $blockService = new BreadcrumbMenuBlockService_Test(
-            'context',
             'name',
-            $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface'),
-            $this->createMock('Knp\Menu\Provider\MenuProviderInterface'),
-            $this->createMock('Knp\Menu\FactoryInterface')
+            $this->createMock(EngineInterface::class),
+            $this->createMock(FactoryInterface::class)
         );
 
         $this->assertTrue($blockService->handleContext('context'));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - the block context is registered in the compiler pass

### Deprecated
 - Deprecated `BaseBreadcrumbMenuBlockService` class in favor of `AbstractBreadcrumbMenuService`

### Removed
 - Removed context from `AbstractBreadcrumbMenuService`
```


## Subject

Abstract classes should start with an `Abstract` prefix.

The new `AbstractBreadcrumbMenuService` class has a slight signature change in the constructor order. This will reduce deprecation warnings, because the first argument in every `*BlockService` should be the service id itself.

The context is removed from the block services itself and is bind via the `context` attribute in the `sonata.breadcrumb` tag.