### PR TITLE
Removed default title

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -48,7 +48,8 @@ class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
                         ->scalarNode('separator')->defaultValue(' - ')->end()
-                        ->scalarNode('title')->defaultValue('Sonata Project')->end()
+                        // NEXT_MAJOR: Make this field required
+                        ->scalarNode('title')->defaultValue('Project name')->end()
                     ->end()
                 ->end()
                 ->arrayNode('sitemap')

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -81,7 +81,7 @@ class ConfigurationTest extends TestCase
                 'head' => [],
                 'metas' => [],
                 'separator' => ' - ',
-                'title' => 'Sonata Project',
+                'title' => 'Project name',
             ],
             'sitemap' => [
                 'doctrine_orm' => [],


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - Changed default title to `Project name`
```

## Subject

There's no reason for `Sonata Project` as the default SEO title.