### PR TITLE
Restore PHP 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "sonata-project/exporter": "^1.2.2",
         "symfony/framework-bundle": "^2.8 || ^3.2 || ^4.0",
         "symfony/options-resolver": "^2.8 || ^3.2 || ^4.0",


### PR DESCRIPTION
After the back and forth of PHP versions, we lost 7.1 on master, which was not intended. This PR restores it.