### PR TITLE
Decouple from Templating Component, Stage 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,13 @@
         "symfony/options-resolver": "^2.8 || ^3.2 || ^4.0",
         "twig/twig": "^1.14.2 || ^2.0"
     },
+    "conflict": {
+        "sonata-project/block-bundle": "<3.11"
+    },
     "require-dev": {
         "guzzle/guzzle": "3.*",
         "sonata-project/admin-bundle": "^3.0",
-        "sonata-project/block-bundle": "^3.7",
+        "sonata-project/block-bundle": "^3.11",
         "symfony/console": "^2.8 || ^3.2 || ^4.0",
         "symfony/finder": "^2.8 || ^3.2 || ^4.0",
         "symfony/phpunit-bridge": "^3.3 || ^4.0"

--- a/docs/reference/social_blocks.rst
+++ b/docs/reference/social_blocks.rst
@@ -28,11 +28,11 @@ layout. You can include them by including these templates :
 
 .. code-block:: jinja
 
-    {% include 'SonataSeoBundle:Block:_facebook_sdk.html.twig' %}
+    {% include '@SonataSeo/Block/_facebook_sdk.html.twig' %}
 
-    {% include 'SonataSeoBundle:Block:_twitter_sdk.html.twig' %}
+    {% include '@SonataSeo/Block/_twitter_sdk.html.twig' %}
 
-    {% include 'SonataSeoBundle:Block:_pinterest_sdk.html.twig' %}
+    {% include '@SonataSeo/Block/_pinterest_sdk.html.twig' %}
 
 Check the related documentation to get more details :
 

--- a/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
+++ b/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
@@ -79,7 +79,7 @@ abstract class BaseBreadcrumbMenuBlockService extends MenuBlockService
         parent::configureSettings($resolver);
 
         $resolver->setDefaults([
-            'menu_template' => 'SonataSeoBundle:Block:breadcrumb.html.twig',
+            'menu_template' => '@SonataSeo/Block/breadcrumb.html.twig',
             'include_homepage_link' => true,
             'context' => false,
         ]);

--- a/src/Block/Social/EmailShareButtonBlockService.php
+++ b/src/Block/Social/EmailShareButtonBlockService.php
@@ -34,7 +34,7 @@ class EmailShareButtonBlockService extends AbstractAdminBlockService
     public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'template' => 'SonataSeoBundle:Block:block_email_share_button.html.twig',
+            'template' => '@SonataSeo/Block/block_email_share_button.html.twig',
             'subject' => null,
             'body' => null,
         ]);

--- a/src/Block/Social/FacebookLikeBoxBlockService.php
+++ b/src/Block/Social/FacebookLikeBoxBlockService.php
@@ -36,7 +36,7 @@ class FacebookLikeBoxBlockService extends BaseFacebookSocialPluginsBlockService
     public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'template' => 'SonataSeoBundle:Block:block_facebook_like_box.html.twig',
+            'template' => '@SonataSeo/Block/block_facebook_like_box.html.twig',
             'url' => null,
             'width' => null,
             'height' => null,

--- a/src/Block/Social/FacebookLikeButtonBlockService.php
+++ b/src/Block/Social/FacebookLikeButtonBlockService.php
@@ -54,7 +54,7 @@ class FacebookLikeButtonBlockService extends BaseFacebookSocialPluginsBlockServi
     public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'template' => 'SonataSeoBundle:Block:block_facebook_like_button.html.twig',
+            'template' => '@SonataSeo/Block/block_facebook_like_button.html.twig',
             'url' => null,
             'width' => null,
             'show_faces' => true,

--- a/src/Block/Social/FacebookSendButtonBlockService.php
+++ b/src/Block/Social/FacebookSendButtonBlockService.php
@@ -35,7 +35,7 @@ class FacebookSendButtonBlockService extends BaseFacebookSocialPluginsBlockServi
     public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'template' => 'SonataSeoBundle:Block:block_facebook_send_button.html.twig',
+            'template' => '@SonataSeo/Block/block_facebook_send_button.html.twig',
             'url' => null,
             'width' => null,
             'height' => null,

--- a/src/Block/Social/FacebookShareButtonBlockService.php
+++ b/src/Block/Social/FacebookShareButtonBlockService.php
@@ -47,7 +47,7 @@ class FacebookShareButtonBlockService extends BaseFacebookSocialPluginsBlockServ
     public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'template' => 'SonataSeoBundle:Block:block_facebook_share_button.html.twig',
+            'template' => '@SonataSeo/Block/block_facebook_share_button.html.twig',
             'url' => null,
             'width' => null,
             'layout' => $this->layoutList['box_count'],

--- a/src/Block/Social/PinterestPinButtonBlockService.php
+++ b/src/Block/Social/PinterestPinButtonBlockService.php
@@ -39,7 +39,7 @@ class PinterestPinButtonBlockService extends AbstractAdminBlockService
     public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'template' => 'SonataSeoBundle:Block:block_pinterest_pin_button.html.twig',
+            'template' => '@SonataSeo/Block/block_pinterest_pin_button.html.twig',
             'size' => null,
             'shape' => null,
             'url' => null,

--- a/src/Block/Social/TwitterEmbedTweetBlockService.php
+++ b/src/Block/Social/TwitterEmbedTweetBlockService.php
@@ -78,7 +78,7 @@ class TwitterEmbedTweetBlockService extends BaseTwitterButtonBlockService
     public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'template' => 'SonataSeoBundle:Block:block_twitter_embed.html.twig',
+            'template' => '@SonataSeo/Block/block_twitter_embed.html.twig',
             'tweet' => '',
             'maxwidth' => null,
             'hide_media' => false,

--- a/src/Block/Social/TwitterFollowButtonBlockService.php
+++ b/src/Block/Social/TwitterFollowButtonBlockService.php
@@ -35,7 +35,7 @@ class TwitterFollowButtonBlockService extends BaseTwitterButtonBlockService
     public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'template' => 'SonataSeoBundle:Block:block_twitter_follow_button.html.twig',
+            'template' => '@SonataSeo/Block/block_twitter_follow_button.html.twig',
             'user' => null,
             'show_username' => true,
             'large_button' => false,

--- a/src/Block/Social/TwitterHashtagButtonBlockService.php
+++ b/src/Block/Social/TwitterHashtagButtonBlockService.php
@@ -36,7 +36,7 @@ class TwitterHashtagButtonBlockService extends BaseTwitterButtonBlockService
     public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'template' => 'SonataSeoBundle:Block:block_twitter_hashtag_button.html.twig',
+            'template' => '@SonataSeo/Block/block_twitter_hashtag_button.html.twig',
             'url' => null,
             'hashtag' => null,
             'text' => null,

--- a/src/Block/Social/TwitterMentionButtonBlockService.php
+++ b/src/Block/Social/TwitterMentionButtonBlockService.php
@@ -35,7 +35,7 @@ class TwitterMentionButtonBlockService extends BaseTwitterButtonBlockService
     public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'template' => 'SonataSeoBundle:Block:block_twitter_mention_button.html.twig',
+            'template' => '@SonataSeo/Block/block_twitter_mention_button.html.twig',
             'user' => null,
             'text' => null,
             'recommend' => null,

--- a/src/Block/Social/TwitterShareButtonBlockService.php
+++ b/src/Block/Social/TwitterShareButtonBlockService.php
@@ -36,7 +36,7 @@ class TwitterShareButtonBlockService extends BaseTwitterButtonBlockService
     public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'template' => 'SonataSeoBundle:Block:block_twitter_share_button.html.twig',
+            'template' => '@SonataSeo/Block/block_twitter_share_button.html.twig',
             'url' => null,
             'text' => null,
             'show_count' => true,

--- a/src/Resources/config/blocks.xml
+++ b/src/Resources/config/blocks.xml
@@ -22,65 +22,65 @@
         <service id="sonata.seo.block.email.share_button" class="%sonata.seo.block.email.share_button.class%" public="true">
             <tag name="sonata.block"/>
             <argument>sonata.seo.block.email.share_button</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
         <!-- Email buttons -->
         <!-- Facebook Social Plugins -->
         <service id="sonata.seo.block.facebook.like_box" class="%sonata.seo.block.facebook.like_box.class%" public="true">
             <tag name="sonata.block"/>
             <argument>sonata.seo.block.facebook.like_box</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
         <service id="sonata.seo.block.facebook.like_button" class="%sonata.seo.block.facebook.like_button.class%" public="true">
             <tag name="sonata.block"/>
             <argument>sonata.seo.block.facebook.like_button</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
         <service id="sonata.seo.block.facebook.send_button" class="%sonata.seo.block.facebook.send_button.class%" public="true">
             <tag name="sonata.block"/>
             <argument>sonata.seo.block.facebook.send_button</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
         <service id="sonata.seo.block.facebook.share_button" class="%sonata.seo.block.facebook.share_button.class%" public="true">
             <tag name="sonata.block"/>
             <argument>sonata.seo.block.facebook.share_button</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
         <!-- Facebook Social Plugins -->
         <!-- Twitter buttons -->
         <service id="sonata.seo.block.twitter.share_button" class="%sonata.seo.block.twitter.share_button.class%" public="true">
             <tag name="sonata.block"/>
             <argument>sonata.seo.block.twitter.share_button</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
         <service id="sonata.seo.block.twitter.follow_button" class="%sonata.seo.block.twitter.follow_button.class%" public="true">
             <tag name="sonata.block"/>
             <argument>sonata.seo.block.twitter.follow_button</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
         <service id="sonata.seo.block.twitter.hashtag_button" class="%sonata.seo.block.twitter.hashtag_button.class%" public="true">
             <tag name="sonata.block"/>
             <argument>sonata.seo.block.twitter.hashtag_button</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
         <service id="sonata.seo.block.twitter.mention_button" class="%sonata.seo.block.twitter.mention_button.class%" public="true">
             <tag name="sonata.block"/>
             <argument>sonata.seo.block.twitter.mention_button</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
         <!-- Twitter buttons -->
         <!-- Twitter embed -->
         <service id="sonata.seo.block.twitter.embed" class="%sonata.seo.block.twitter.embed.class%" public="true">
             <tag name="sonata.block"/>
             <argument>sonata.seo.block.twitter.embed</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
         <!-- Twitter embed -->
         <!-- Pinterest buttons -->
         <service id="sonata.seo.block.pinterest.pin_button" class="%sonata.seo.block.pinterest.pin_button.class%" public="true">
             <tag name="sonata.block"/>
             <argument>sonata.seo.block.pinterest.pin_button</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
         <!-- Pinterest buttons -->
         <!-- Breadcrumb -->
@@ -89,7 +89,7 @@
             <tag name="sonata.block"/>
             <argument>homepage</argument>
             <argument>sonata.seo.block.breadcrumb.homepage</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument type="service" id="knp_menu.menu_provider"/>
             <argument type="service" id="knp_menu.factory"/>
         </service>


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Switch all templates references to Twig namespaced syntax
- Switch from templating service to sonata.templating
```

## To do

- [X] Switch all templates references to Twig namespaced syntax. Update docs, src and tests
- [x] Add `sonata-project/block-bundle` to composer.json
- [x] Switch from `templating` service to `sonata.templating`

## Subject

This PR is a part of a big plan of decoupling sonata-project bundles from Templating Component. See sonata-project/dev-kit#380 for details