### PR TITLE
Register Symfony Command

### DIFF
--- a/src/DependencyInjection/SonataSeoExtension.php
+++ b/src/DependencyInjection/SonataSeoExtension.php
@@ -43,6 +43,7 @@ class SonataSeoExtension extends Extension
 
         $loader->load('event.xml');
         $loader->load('services.xml');
+        $loader->load('commands.xml');
 
         $this->configureSeoPage($config['page'], $container);
         $this->configureSitemap($config['sitemap'], $container);

--- a/src/Resources/config/commands.xml
+++ b/src/Resources/config/commands.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Sonata\SeoBundle\Command\SitemapGeneratorCommand" class="Sonata\SeoBundle\Command\SitemapGeneratorCommand">
+            <tag name="console.command"/>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
I am targeting this branch, because there is no BC-break.

## Subject

I am adding this code because the command is not automatically registered.

## Changelog
```markdown
### Fixed
+ Register `Sonata\SeoBundle\Command\SitemapGeneratorCommand` via `console.command` tag
```
