### PR TITLE
Allow overriding default seo service

### DIFF
--- a/src/DependencyInjection/Compiler/ServiceCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ServiceCompilerPass.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\SeoBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+final class ServiceCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $config = $container->getParameter('sonata.seo.config');
+
+        $definition = $container->findDefinition($config['default']);
+
+        $definition->addMethodCall('setTitle', [$config['title']]);
+        $definition->addMethodCall('setMetas', [$config['metas']]);
+        $definition->addMethodCall('setHtmlAttributes', [$config['head']]);
+        $definition->addMethodCall('setSeparator', [$config['separator']]);
+
+        if ($alias = $container->setAlias('sonata.seo.page', $config['default'])) {
+            $alias->setPublic(true);
+        }
+    }
+}

--- a/src/DependencyInjection/SonataSeoExtension.php
+++ b/src/DependencyInjection/SonataSeoExtension.php
@@ -60,16 +60,7 @@ class SonataSeoExtension extends Extension
      */
     protected function configureSeoPage(array $config, ContainerBuilder $container)
     {
-        $definition = $container->getDefinition($config['default']);
-
-        $definition->addMethodCall('setTitle', [$config['title']]);
-        $definition->addMethodCall('setMetas', [$config['metas']]);
-        $definition->addMethodCall('setHtmlAttributes', [$config['head']]);
-        $definition->addMethodCall('setSeparator', [$config['separator']]);
-
-        if ($alias = $container->setAlias('sonata.seo.page', $config['default'])) {
-            $alias->setPublic(true);
-        }
+        $container->setParameter('sonata.seo.config', $config);
     }
 
     /**

--- a/src/SonataSeoBundle.php
+++ b/src/SonataSeoBundle.php
@@ -12,6 +12,7 @@
 namespace Sonata\SeoBundle;
 
 use Sonata\SeoBundle\DependencyInjection\Compiler\BreadcrumbBlockServicesCompilerPass;
+use Sonata\SeoBundle\DependencyInjection\Compiler\ServiceCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -25,5 +26,6 @@ class SonataSeoBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new BreadcrumbBlockServicesCompilerPass());
+        $container->addCompilerPass(new ServiceCompilerPass());
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Allow overriding default seo service
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

Now you can override the default seo service outside the seo bundle scope:

```yaml
sonata_seo:
    page:
        default 'acme.seo.page'
```
