### PR TITLE
Added the SeoPageInterface to the container as an alias.

### DIFF
--- a/src/DependencyInjection/Compiler/ServiceCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ServiceCompilerPass.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\DependencyInjection\Compiler;
 
+use Sonata\SeoBundle\Seo\SeoPageInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -35,5 +36,7 @@ final class ServiceCompilerPass implements CompilerPassInterface
         if ($alias = $container->setAlias('sonata.seo.page', $config['default'])) {
             $alias->setPublic(true);
         }
+
+        $container->setAlias(SeoPageInterface::class, $config['default']);
     }
 }

--- a/tests/DependencyInjection/Compiler/ServiceCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ServiceCompilerPassTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\SeoBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\SeoBundle\DependencyInjection\Compiler\ServiceCompilerPass;
+use Sonata\SeoBundle\DependencyInjection\SonataSeoExtension;
+use Sonata\SeoBundle\Seo\SeoPageInterface;
+use Sonata\SeoBundle\Tests\Stubs\SeoPageStub;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ServiceCompilerPassTest extends TestCase
+{
+    public function testServicesExistsAndCanBeOverridden()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.bundles', []);
+
+        $container->register('sonata.seo.custom.page', SeoPageStub::class);
+
+        $config = [
+            'page' => [
+                'default' => 'sonata.seo.custom.page'
+            ]
+        ];
+
+        $extension = new SonataSeoExtension();
+        $extension->load([$config], $container);
+
+        (new ServiceCompilerPass())->process($container);
+
+        $this->assertTrue($service = $container->has('sonata.seo.page'));
+        $this->assertTrue($alias = $container->has(SeoPageInterface::class));
+        $this->assertSame($service, $alias);
+
+        $this->assertInstanceOf(SeoPageStub::class, $container->get(SeoPageInterface::class));
+    }
+}

--- a/tests/DependencyInjection/Compiler/ServiceCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ServiceCompilerPassTest.php
@@ -31,8 +31,8 @@ class ServiceCompilerPassTest extends TestCase
 
         $config = [
             'page' => [
-                'default' => 'sonata.seo.custom.page'
-            ]
+                'default' => 'sonata.seo.custom.page',
+            ],
         ];
 
         $extension = new SonataSeoExtension();

--- a/tests/Stubs/SeoPageStub.php
+++ b/tests/Stubs/SeoPageStub.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\SeoBundle\Tests\Stubs;
+
+use Sonata\SeoBundle\Seo\SeoPage;
+
+class SeoPageStub extends SeoPage
+{
+
+}

--- a/tests/Stubs/SeoPageStub.php
+++ b/tests/Stubs/SeoPageStub.php
@@ -17,5 +17,4 @@ use Sonata\SeoBundle\Seo\SeoPage;
 
 class SeoPageStub extends SeoPage
 {
-
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Added the `SeoPageInterface` as an alias in the container. This way developers can use Dependency Injection to grab the SeoPage class they configured in their configuration. 

The `SeoPageInterface` wil always be the instance which is configured in the `sonata_seo.page.default` setting.

I am targeting this branch, because it's a new feature.


Closes #320 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataSeoBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `SeoPageInterface` as alias service of `sonata.seo.page` for Dependency Injection usages.
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
