### PR TITLE
Cast metadata to string

### DIFF
--- a/src/Twig/Extension/SeoExtension.php
+++ b/src/Twig/Extension/SeoExtension.php
@@ -262,6 +262,6 @@ class SeoExtension extends \Twig_Extension
      */
     private function normalize($string)
     {
-        return htmlentities(strip_tags($string), ENT_COMPAT, $this->encoding);
+        return htmlentities(strip_tags((string) $string), ENT_COMPAT, $this->encoding);
     }
 }

--- a/tests/Twig/Extension/SeoExtensionTest.php
+++ b/tests/Twig/Extension/SeoExtensionTest.php
@@ -85,13 +85,16 @@ class SeoExtensionTest extends TestCase
             'name' => ['foo' => ['bar "\'"', []]],
             'schema' => [],
             'charset' => ['UTF-8' => ['', []]],
-            'property' => [],
+            'property' => [
+                'og:image:width' => [848, []],
+                'og:type' => [new MetaTest(), []],
+            ],
         ]));
 
         $extension = new SeoExtension($page, 'UTF-8');
 
         $this->assertSame(
-            "<meta name=\"foo\" content=\"bar &quot;'&quot;\" />\n<meta charset=\"UTF-8\" />\n",
+            "<meta name=\"foo\" content=\"bar &quot;'&quot;\" />\n<meta charset=\"UTF-8\" />\n<meta property=\"og:image:width\" content=\"848\" />\n<meta property=\"og:type\" content=\"article\" />\n",
             $extension->getMetadatas()
         );
     }
@@ -145,5 +148,13 @@ class SeoExtensionTest extends TestCase
             "<link rel=\"alternate\" type=\"application/json+oembed\" href=\"http://example.com/\" title=\"Foo\" />\n",
             $extension->getOembedLinks()
         );
+    }
+}
+
+class MetaTest
+{
+    public function __toString()
+    {
+        return 'article';
     }
 }


### PR DESCRIPTION
## Subject

Strict types were added in the latest version (#313), which causes metadata values to not be implicitly converted to strings anymore.
Most notably what I picked up is the [currency in the ProductBundle](https://github.com/sonata-project/ecommerce/blob/2.x/src/ProductBundle/Seo/Services/Facebook.php#L96) which is an object (containing a `__toString` method) and the [image dimensions for a product](https://github.com/sonata-project/ecommerce/blob/2.x/src/ProductBundle/Seo/Services/Facebook.php#L113-L114) which are integers.

I am targeting this branch, because it is a bug fix introduced in the latest stable version.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- cast metadata to string during render
```

