### PR TITLE
Deprecate passing non-string meta content

### DIFF
--- a/src/Seo/SeoPage.php
+++ b/src/Seo/SeoPage.php
@@ -119,8 +119,16 @@ class SeoPage implements SeoPageInterface
     /**
      * {@inheritdoc}
      */
-    public function addMeta($type, $name, $content, array $extras = [])
+    public function addMeta($type, $name, /* string */ $content, array $extras = [])
     {
+        if (!\is_string($content)) {
+            @trigger_error(sprintf(
+                'Passing meta content of type %s in %s is deprecated since version 2.x and will be unsupported in version 3. Please cast the value to a string first.',
+                 \gettype($content),
+                  __METHOD__
+              ), E_USER_DEPRECATED);
+        }
+
         if (!isset($this->metas[$type])) {
             $this->metas[$type] = [];
         }

--- a/tests/Seo/SeoPageTest.php
+++ b/tests/Seo/SeoPageTest.php
@@ -154,7 +154,7 @@ class SeoPageTest extends TestCase
     public function testHasMeta()
     {
         $page = new SeoPage();
-        $page->addMeta('property', 'test', []);
+        $page->addMeta('property', 'test', '');
 
         $this->assertTrue($page->hasMeta('property', 'test'));
         $this->assertFalse($page->hasMeta('property', 'fake'));


### PR DESCRIPTION
## Subject

This is a follow-up to #330, to deprecate passing non-string values for meta content.

## Changelog

```markdown
### Deprecated
- passing a non-string value when adding meta content
```
