### PR TITLE
Bump Twig to 1.40|2.9 and replace deprecated spaceless tags with apply spaceless filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/http-foundation": "^2.8 || ^3.2 || ^4.0",
         "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0",
         "symfony/options-resolver": "^2.8 || ^3.2 || ^4.0",
-        "twig/twig": "^1.35 || ^2.4"
+        "twig/twig": "^1.40 || ^2.9"
     },
     "conflict": {
         "sonata-project/block-bundle": "<3.11"

--- a/src/Resources/views/Block/_facebook_sdk.html.twig
+++ b/src/Resources/views/Block/_facebook_sdk.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 {% block facebook_sdk %}
-{% spaceless %}
+{% apply spaceless %}
 
     <div id="fb-root"></div>
     <script>(function(d, s, id) {
@@ -21,5 +21,5 @@ file that was distributed with this source code.
         }(document, 'script', 'facebook-jssdk'));
     </script>
 
-{% endspaceless %}
+{% endapply %}
 {% endblock %}

--- a/src/Resources/views/Block/_pinterest_sdk.html.twig
+++ b/src/Resources/views/Block/_pinterest_sdk.html.twig
@@ -9,9 +9,9 @@ file that was distributed with this source code.
 
 #}
 {% block pinterest_sdk %}
-    {% spaceless %}
+    {% apply spaceless %}
 
         <script type="text/javascript" async src="//assets.pinterest.com/js/pinit.js"></script>
 
-    {% endspaceless %}
+    {% endapply %}
 {% endblock %}

--- a/src/Resources/views/Block/_twitter_sdk.html.twig
+++ b/src/Resources/views/Block/_twitter_sdk.html.twig
@@ -9,9 +9,7 @@ file that was distributed with this source code.
 
 #}
 {% block twitter_sdk %}
-{% spaceless %}
-
+{% apply spaceless %}
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-
-{% endspaceless %}
+{% endapply %}
 {% endblock %}

--- a/src/Resources/views/Block/block_email_share_button.html.twig
+++ b/src/Resources/views/Block/block_email_share_button.html.twig
@@ -11,11 +11,11 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-    {% spaceless %}
+    {% apply spaceless %}
 
         <a href="mailto:?subject={{ settings.subject }}&body={{ settings.body }}">
             {% trans from 'SonataSeoBundle' %}sonata_seo_share_by_email{% endtrans %}
         </a>
 
-    {% endspaceless %}
+    {% endapply %}
 {% endblock %}

--- a/src/Resources/views/Block/block_facebook_like_box.html.twig
+++ b/src/Resources/views/Block/block_facebook_like_box.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-{% spaceless %}
+{% apply spaceless %}
 
     <div class="fb-like-box"
         {% if settings.url %}data-href="{{ settings.url }}"{% endif %}
@@ -24,5 +24,5 @@ file that was distributed with this source code.
         data-colorscheme="{{ settings.colorscheme }}">
     </div>
 
-{% endspaceless %}
+{% endapply %}
 {% endblock %}

--- a/src/Resources/views/Block/block_facebook_like_button.html.twig
+++ b/src/Resources/views/Block/block_facebook_like_button.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-{% spaceless %}
+{% apply spaceless %}
 
     <div class="fb-like"
         {% if settings.url %}data-href="{{ settings.url }}"{% endif %}
@@ -23,5 +23,5 @@ file that was distributed with this source code.
         data-colorscheme="{{ settings.colorscheme }}">
     </div>
 
-{% endspaceless %}
+{% endapply %}
 {% endblock %}

--- a/src/Resources/views/Block/block_facebook_send_button.html.twig
+++ b/src/Resources/views/Block/block_facebook_send_button.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-{% spaceless %}
+{% apply spaceless %}
 
     <div class="fb-send"
         {% if settings.url %}data-href="{{ settings.url }}"{% endif %}
@@ -20,5 +20,5 @@ file that was distributed with this source code.
         {% if settings.height %}data-height="{{ settings.height }}"{% endif %}>
     </div>
 
-{% endspaceless %}
+{% endapply %}
 {% endblock %}

--- a/src/Resources/views/Block/block_facebook_share_button.html.twig
+++ b/src/Resources/views/Block/block_facebook_share_button.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-{% spaceless %}
+{% apply spaceless %}
 
     <div class="fb-share-button"
         {% if settings.url %}data-href="{{ settings.url }}"{% endif %}
@@ -19,5 +19,5 @@ file that was distributed with this source code.
         data-type="{{ settings.layout }}">
     </div>
 
-{% endspaceless %}
+{% endapply %}
 {% endblock %}

--- a/src/Resources/views/Block/block_pinterest_pin_button.html.twig
+++ b/src/Resources/views/Block/block_pinterest_pin_button.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-    {% spaceless %}
+    {% apply spaceless %}
 
         <a href="//www.pinterest.com/pin/create/button/?url={{ settings.url }}&media={{ settings.image }}&description={{ settings.description }}"
            data-pin-do="buttonPin"
@@ -20,5 +20,5 @@ file that was distributed with this source code.
             <img src="//assets.pinterest.com/images/pidgets/pinit_fg_en_rect_gray_20.png" />
         </a>
 
-    {% endspaceless %}
+    {% endapply %}
 {% endblock %}

--- a/src/Resources/views/Block/block_twitter_embed.html.twig
+++ b/src/Resources/views/Block/block_twitter_embed.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-    {% spaceless %}
+    {% apply spaceless %}
         {{ tweet|raw }}
-    {% endspaceless %}
+    {% endapply %}
 {% endblock %}

--- a/src/Resources/views/Block/block_twitter_follow_button.html.twig
+++ b/src/Resources/views/Block/block_twitter_follow_button.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-{% spaceless %}
+{% apply spaceless %}
 
     {% if settings.user %}
 
@@ -25,5 +25,5 @@ file that was distributed with this source code.
 
     {% endif %}
 
-{% endspaceless %}
+{% endapply %}
 {% endblock %}

--- a/src/Resources/views/Block/block_twitter_hashtag_button.html.twig
+++ b/src/Resources/views/Block/block_twitter_hashtag_button.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-{% spaceless %}
+{% apply spaceless %}
 
     {% if settings.hashtag %}
 
@@ -27,5 +27,5 @@ file that was distributed with this source code.
 
     {% endif %}
 
-{% endspaceless %}
+{% endapply %}
 {% endblock %}

--- a/src/Resources/views/Block/block_twitter_mention_button.html.twig
+++ b/src/Resources/views/Block/block_twitter_mention_button.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-{% spaceless %}
+{% apply spaceless %}
 
     {% if settings.user %}
 
@@ -27,5 +27,5 @@ file that was distributed with this source code.
 
     {% endif %}
 
-{% endspaceless %}
+{% endapply %}
 {% endblock %}

--- a/src/Resources/views/Block/block_twitter_share_button.html.twig
+++ b/src/Resources/views/Block/block_twitter_share_button.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-{% spaceless %}
+{% apply spaceless %}
 
     <a href="https://twitter.com/share" class="twitter-share-button"
         {% if settings.url %}data-url="{{ settings.url }}"{% endif %}
@@ -26,5 +26,5 @@ file that was distributed with this source code.
         Tweet
     </a>
 
-{% endspaceless %}
+{% endapply %}
 {% endblock %}

--- a/src/Resources/views/Block/breadcrumb.html.twig
+++ b/src/Resources/views/Block/breadcrumb.html.twig
@@ -23,9 +23,9 @@ file that was distributed with this source code.
 {% endblock %}
 
 {% block list %}
-{% spaceless %}
+{% apply spaceless %}
     <div class="sonata_breadcrumb">
         {{ parent() }}
     </div>
-{% endspaceless %}
+{% endapply %}
 {% endblock %}


### PR DESCRIPTION
## Fix deprecated use of the `spaceless` Twig tag


I am targeting this branch, because it has no effect for the end user, except fixing some deprecations with more recent Twig versions.

Closes #339 

## Changelog

```markdown
### Fixed
- Fixed use of deprecated `spaceless` Twig tag
```