### PR TITLE
Dropping support for symfony < 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
     "require": {
         "php": "^7.1",
         "sonata-project/exporter": "^1.11 || ^2.0",
-        "symfony/config": "^2.8 || ^3.2 || ^4.0",
-        "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
-        "symfony/form": "^2.8 || ^3.2 || ^4.0",
-        "symfony/framework-bundle": "^2.8 || ^3.2 || ^4.0",
-        "symfony/http-foundation": "^2.8 || ^3.2 || ^4.0",
-        "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0",
-        "symfony/options-resolver": "^2.8 || ^3.2 || ^4.0",
+        "symfony/config": "^3.4 || ^4.2",
+        "symfony/dependency-injection": "^3.4 || ^4.2",
+        "symfony/form": "^3.4 || ^4.2",
+        "symfony/framework-bundle": "^3.4 || ^4.2",
+        "symfony/http-foundation": "^3.4 || ^4.2",
+        "symfony/http-kernel": "^3.4 || ^4.2",
+        "symfony/options-resolver": "^3.4 || ^4.2",
         "twig/twig": "^1.40 || ^2.9"
     },
     "conflict": {
@@ -39,11 +39,11 @@
         "sonata-project/admin-bundle": "^3.31",
         "sonata-project/block-bundle": "^3.11",
         "sonata-project/core-bundle": "^3.9",
-        "symfony/console": "^2.8 || ^3.2 || ^4.0",
-        "symfony/filesystem": "^2.8 || ^3.2 || ^4.0",
-        "symfony/finder": "^2.8 || ^3.2 || ^4.0",
+        "symfony/console": "^3.4 || ^4.2",
+        "symfony/filesystem": "^3.4 || ^4.2",
+        "symfony/finder": "^3.4 || ^4.2",
         "symfony/phpunit-bridge": "^4.1",
-        "symfony/yaml": "^2.8 || ^3.2 || ^4.0"
+        "symfony/yaml": "^3.4 || ^4.2"
     },
     "suggest": {
         "guzzle/guzzle": "3.*",

--- a/src/DependencyInjection/SonataSeoExtension.php
+++ b/src/DependencyInjection/SonataSeoExtension.php
@@ -15,7 +15,6 @@ namespace Sonata\SeoBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
@@ -69,12 +68,7 @@ class SonataSeoExtension extends Extension
     {
         $source = $container->getDefinition('sonata.seo.sitemap.manager');
 
-        if (method_exists($source, 'setShared')) { // Symfony 2.8+
-            $source->setShared(false);
-        } else {
-            // For Symfony <2.8 compatibility
-            $source->setScope(ContainerInterface::SCOPE_PROTOTYPE);
-        }
+        $source->setShared(false);
 
         foreach ($config['doctrine_orm'] as $pos => $sitemap) {
             // define the connectionIterator

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -67,10 +67,7 @@ class ConfigurationTest extends TestCase
     {
         $values = Yaml::parse(
             file_get_contents(__DIR__.'/data/config.yml'),
-            // NEXT_MAJOR: use constant when dropping Symfony < 3.1
-            \defined('Symfony\Component\Yaml\Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE') ?
-            Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE :
-            true
+            Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE
         );
 
         $config = $this->processConfiguration([$values]);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This is the same thing as https://github.com/sonata-project/SonataAdminBundle/pull/5733, dropping support of Symfony < 3.4 and >= 4, < 4.2
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Support for Symfony < 3.4
- Support for Symfony >= 4, < 4.2
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
