### PR TITLE
Add support for Symfony 5 and Twig 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,14 @@
     "require": {
         "php": "^7.1",
         "sonata-project/exporter": "^1.11 || ^2.0",
-        "symfony/config": "^3.4 || ^4.2",
-        "symfony/dependency-injection": "^3.4 || ^4.2",
-        "symfony/form": "^3.4 || ^4.2",
-        "symfony/framework-bundle": "^3.4 || ^4.2",
-        "symfony/http-foundation": "^3.4 || ^4.2",
-        "symfony/http-kernel": "^3.4 || ^4.2",
-        "symfony/options-resolver": "^3.4 || ^4.2",
-        "twig/twig": "^1.40 || ^2.9"
+        "symfony/config": "^3.4 || ^4.2 || ^5.0",
+        "symfony/dependency-injection": "^3.4 || ^4.2 || ^5.0",
+        "symfony/form": "^3.4 || ^4.2 || ^5.0",
+        "symfony/framework-bundle": "^3.4 || ^4.2 || ^5.0",
+        "symfony/http-foundation": "^3.4 || ^4.2 || ^5.0",
+        "symfony/http-kernel": "^3.4 || ^4.2 || ^5.0",
+        "symfony/options-resolver": "^3.4 || ^4.2 || ^5.0",
+        "twig/twig": "^1.40 || ^2.9 || ^3.0"
     },
     "conflict": {
         "sonata-project/block-bundle": "<3.11"
@@ -39,11 +39,11 @@
         "sonata-project/admin-bundle": "^3.31",
         "sonata-project/block-bundle": "^3.11",
         "sonata-project/core-bundle": "^3.9",
-        "symfony/console": "^3.4 || ^4.2",
-        "symfony/filesystem": "^3.4 || ^4.2",
-        "symfony/finder": "^3.4 || ^4.2",
-        "symfony/phpunit-bridge": "^4.1",
-        "symfony/yaml": "^3.4 || ^4.2"
+        "symfony/console": "^3.4 || ^4.2 || ^5.0",
+        "symfony/filesystem": "^3.4 || ^4.2 || ^5.0",
+        "symfony/finder": "^3.4 || ^4.2 || ^5.0",
+        "symfony/phpunit-bridge": "^4.1 || ^5.0",
+        "symfony/yaml": "^3.4 || ^4.2 || ^5.0"
     },
     "suggest": {
         "guzzle/guzzle": "3.*",


### PR DESCRIPTION
## Add support for Symfony 5 and Twig 3

I guess this one is self explanatory...

I am targeting this branch, because it only adds support for newer versions of Twig and Symfony.

Closes #353

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Support for Twig 3 and Symfony 5
```