### PR TITLE
Remove old sonata dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,12 @@
     ],
     "require": {
         "php": "^7.1",
+        "knplabs/knp-menu": "^2.6",
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0",
+        "sonata-project/block-bundle": "^4.0",
         "sonata-project/exporter": "^1.11 || ^2.0",
+        "sonata-project/form-extensions": "^1.0",
         "symfony/config": "^4.4 || ^5.0",
         "symfony/dependency-injection": "^4.4 || ^5.0",
         "symfony/form": "^4.4 || ^5.0",
@@ -34,17 +37,15 @@
         "twig/twig": "^2.9 || ^3.0"
     },
     "conflict": {
-        "sonata-project/block-bundle": "<3.11"
+        "knplabs/knp-menu-bundle": "<2.3"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^6.0",
+        "knplabs/knp-menu-bundle": "^2.3",
         "nyholm/psr7": "^1.2",
-        "sonata-project/admin-bundle": "^3.31",
-        "sonata-project/block-bundle": "^3.17",
-        "sonata-project/core-bundle": "^3.9",
-        "symfony/console": "^4.4 || ^5.0",
-        "symfony/filesystem": "^4.4 || ^5.0",
-        "symfony/finder": "^4.4 || ^5.0",
+        "symfony/console": "^4.2 || ^5.0",
+        "symfony/filesystem": "^4.2 || ^5.0",
+        "symfony/finder": "^4.2 || ^5.0",
         "symfony/http-client": "^4.4 || ^5.0",
         "symfony/phpunit-bridge": "^4.4 || ^5.0",
         "symfony/yaml": "^4.4 || ^5.0"

--- a/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
+++ b/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
@@ -15,61 +15,43 @@ namespace Sonata\SeoBundle\Block\Breadcrumb;
 
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
-use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Block\Service\MenuBlockService;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Twig\Environment;
 
 /**
  * Abstract class for breadcrumb menu services.
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
-abstract class BaseBreadcrumbMenuBlockService extends MenuBlockService
+abstract class BaseBreadcrumbMenuBlockService extends AbstractBlockService
 {
     /**
-     * @var string
+     * @var MenuBlockService
      */
-    private $context;
+    private $menuBlock;
 
     /**
      * @var FactoryInterface
      */
     private $factory;
 
-    /**
-     * @param string $context
-     * @param string $name
-     */
-    public function __construct($context, $name, EngineInterface $templating, MenuProviderInterface $menuProvider, FactoryInterface $factory)
-    {
-        parent::__construct($name, $templating, $menuProvider);
+    public function __construct(
+        Environment $twig,
+        MenuBlockService $menuBlock,
+        FactoryInterface $factory
+    ) {
+        parent::__construct($twig);
 
-        $this->context = $context;
         $this->factory = $factory;
-    }
-
-    /**
-     * Return true if current BlockService handles the given context.
-     *
-     * @param string $context
-     *
-     * @return bool
-     */
-    public function handleContext($context)
-    {
-        return $this->context === $context;
-    }
-
-    public function getName()
-    {
-        return sprintf('Breadcrumb %s', $this->context);
+        $this->menuBlock = $menuBlock;
     }
 
     public function configureSettings(OptionsResolver $resolver): void
     {
-        parent::configureSettings($resolver);
+        $this->menuBlock->configureSettings($resolver);
 
         $resolver->setDefaults([
             'menu_template' => '@SonataSeo/Block/breadcrumb.html.twig',
@@ -84,14 +66,6 @@ abstract class BaseBreadcrumbMenuBlockService extends MenuBlockService
     protected function getFactory()
     {
         return $this->factory;
-    }
-
-    /**
-     * @return string
-     */
-    protected function getContext()
-    {
-        return $this->context;
     }
 
     /**

--- a/src/Block/Breadcrumb/HomepageBreadcrumbBlockService.php
+++ b/src/Block/Breadcrumb/HomepageBreadcrumbBlockService.php
@@ -22,15 +22,8 @@ use Sonata\BlockBundle\Block\BlockContextInterface;
  */
 final class HomepageBreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
 {
-    public function getName()
-    {
-        return 'Breadcrumb (Homepage)';
-    }
-
     protected function getMenu(BlockContextInterface $blockContext)
     {
-        $menu = $this->getRootMenu($blockContext);
-
-        return $menu;
+        return $this->getRootMenu($blockContext);
     }
 }

--- a/src/Block/Social/BaseFacebookSocialPluginsBlockService.php
+++ b/src/Block/Social/BaseFacebookSocialPluginsBlockService.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\SeoBundle\Block\Social;
 
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
-abstract class BaseFacebookSocialPluginsBlockService extends AbstractAdminBlockService
+abstract class BaseFacebookSocialPluginsBlockService extends AbstractBlockService
 {
     /**
      * @var string[]
@@ -32,7 +32,7 @@ abstract class BaseFacebookSocialPluginsBlockService extends AbstractAdminBlockS
         'dark' => 'form.label_colorscheme_dark',
     ];
 
-    public function execute(BlockContextInterface $blockContext, Response $response = null)
+    public function execute(BlockContextInterface $blockContext, Response $response = null): Response
     {
         $settings = $blockContext->getSettings();
 

--- a/src/Block/Social/BaseTwitterButtonBlockService.php
+++ b/src/Block/Social/BaseTwitterButtonBlockService.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\SeoBundle\Block\Social;
 
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
-abstract class BaseTwitterButtonBlockService extends AbstractAdminBlockService
+abstract class BaseTwitterButtonBlockService extends AbstractBlockService
 {
     /**
      * @var string[]
@@ -70,7 +70,7 @@ abstract class BaseTwitterButtonBlockService extends AbstractAdminBlockService
         'en-gb' => 'en-gb',
     ];
 
-    public function execute(BlockContextInterface $blockContext, Response $response = null)
+    public function execute(BlockContextInterface $blockContext, Response $response = null): Response
     {
         $settings = $blockContext->getSettings();
 

--- a/src/Block/Social/EmailShareButtonBlockService.php
+++ b/src/Block/Social/EmailShareButtonBlockService.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\Block\Social;
 
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
+use Sonata\BlockBundle\Meta\Metadata;
+use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
-use Sonata\CoreBundle\Model\Metadata;
+use Sonata\Form\Type\ImmutableArrayType;
+use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -28,7 +31,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
-final class EmailShareButtonBlockService extends AbstractAdminBlockService
+final class EmailShareButtonBlockService extends AbstractBlockService implements EditableBlockService
 {
     public function configureSettings(OptionsResolver $resolver): void
     {
@@ -39,9 +42,14 @@ final class EmailShareButtonBlockService extends AbstractAdminBlockService
         ]);
     }
 
-    public function buildEditForm(FormMapper $formMapper, BlockInterface $block): void
+    public function configureCreateForm(FormMapper $form, BlockInterface $block): void
     {
-        $formMapper->add('settings', ImmutableArrayType::class, [
+        $this->configureEditForm($form, $block);
+    }
+
+    public function configureEditForm(FormMapper $form, BlockInterface $block): void
+    {
+        $form->add('settings', ImmutableArrayType::class, [
             'keys' => [
                 ['subject', TextType::class, [
                     'required' => false,
@@ -56,7 +64,11 @@ final class EmailShareButtonBlockService extends AbstractAdminBlockService
         ]);
     }
 
-    public function execute(BlockContextInterface $blockContext, Response $response = null)
+    public function validate(ErrorElement $errorElement, BlockInterface $block): void
+    {
+    }
+
+    public function execute(BlockContextInterface $blockContext, Response $response = null): Response
     {
         $block = $blockContext->getBlock();
         $settings = array_merge($blockContext->getSettings(), $block->getSettings());
@@ -67,9 +79,9 @@ final class EmailShareButtonBlockService extends AbstractAdminBlockService
         ], $response);
     }
 
-    public function getBlockMetadata($code = null)
+    public function getMetadata(): MetadataInterface
     {
-        return new Metadata($this->getName(), (null !== $code ? $code : $this->getName()), false, 'SonataSeoBundle', [
+        return new Metadata('sonata.seo.block.email.share_button', null, null, 'SonataSeoBundle', [
             'class' => 'fa fa-envelope-o',
         ]);
     }

--- a/src/Block/Social/FacebookLikeBoxBlockService.php
+++ b/src/Block/Social/FacebookLikeBoxBlockService.php
@@ -13,10 +13,13 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\Block\Social;
 
-use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
+use Sonata\BlockBundle\Meta\Metadata;
+use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
-use Sonata\CoreBundle\Model\Metadata;
+use Sonata\Form\Type\ImmutableArrayType;
+use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
@@ -30,7 +33,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
-final class FacebookLikeBoxBlockService extends BaseFacebookSocialPluginsBlockService
+final class FacebookLikeBoxBlockService extends BaseFacebookSocialPluginsBlockService implements EditableBlockService
 {
     public function configureSettings(OptionsResolver $resolver): void
     {
@@ -47,9 +50,14 @@ final class FacebookLikeBoxBlockService extends BaseFacebookSocialPluginsBlockSe
         ]);
     }
 
-    public function buildEditForm(FormMapper $formMapper, BlockInterface $block): void
+    public function configureCreateForm(FormMapper $form, BlockInterface $block): void
     {
-        $formMapper->add('settings', ImmutableArrayType::class, [
+        $this->configureEditForm($form, $block);
+    }
+
+    public function configureEditForm(FormMapper $form, BlockInterface $block): void
+    {
+        $form->add('settings', ImmutableArrayType::class, [
             'keys' => [
                 ['url', UrlType::class, [
                     'required' => false,
@@ -89,9 +97,13 @@ final class FacebookLikeBoxBlockService extends BaseFacebookSocialPluginsBlockSe
         ]);
     }
 
-    public function getBlockMetadata($code = null)
+    public function validate(ErrorElement $errorElement, BlockInterface $block): void
     {
-        return new Metadata($this->getName(), (null !== $code ? $code : $this->getName()), false, 'SonataSeoBundle', [
+    }
+
+    public function getMetadata(): MetadataInterface
+    {
+        return new Metadata('sonata.seo.block.facebook.like_box', null, null, 'SonataSeoBundle', [
             'class' => 'fa fa-facebook-official',
         ]);
     }

--- a/src/Block/Social/FacebookLikeButtonBlockService.php
+++ b/src/Block/Social/FacebookLikeButtonBlockService.php
@@ -13,10 +13,13 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\Block\Social;
 
-use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
+use Sonata\BlockBundle\Meta\Metadata;
+use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
-use Sonata\CoreBundle\Model\Metadata;
+use Sonata\Form\Type\ImmutableArrayType;
+use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
@@ -30,7 +33,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
-final class FacebookLikeButtonBlockService extends BaseFacebookSocialPluginsBlockService
+final class FacebookLikeButtonBlockService extends BaseFacebookSocialPluginsBlockService implements EditableBlockService
 {
     /**
      * @var string[]
@@ -64,9 +67,14 @@ final class FacebookLikeButtonBlockService extends BaseFacebookSocialPluginsBloc
         ]);
     }
 
-    public function buildEditForm(FormMapper $formMapper, BlockInterface $block): void
+    public function configureCreateForm(FormMapper $form, BlockInterface $block): void
     {
-        $formMapper->add('settings', ImmutableArrayType::class, [
+        $this->configureEditForm($form, $block);
+    }
+
+    public function configureEditForm(FormMapper $form, BlockInterface $block): void
+    {
+        $form->add('settings', ImmutableArrayType::class, [
             'keys' => [
                 ['url', UrlType::class, [
                     'required' => false,
@@ -104,9 +112,13 @@ final class FacebookLikeButtonBlockService extends BaseFacebookSocialPluginsBloc
         ]);
     }
 
-    public function getBlockMetadata($code = null)
+    public function validate(ErrorElement $errorElement, BlockInterface $block): void
     {
-        return new Metadata($this->getName(), (null !== $code ? $code : $this->getName()), false, 'SonataSeoBundle', [
+    }
+
+    public function getMetadata(): MetadataInterface
+    {
+        return new Metadata('sonata.seo.block.facebook.like_button', null, null, 'SonataSeoBundle', [
             'class' => 'fa fa-facebook-official',
         ]);
     }

--- a/src/Block/Social/FacebookSendButtonBlockService.php
+++ b/src/Block/Social/FacebookSendButtonBlockService.php
@@ -13,10 +13,13 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\Block\Social;
 
-use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
+use Sonata\BlockBundle\Meta\Metadata;
+use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
-use Sonata\CoreBundle\Model\Metadata;
+use Sonata\Form\Type\ImmutableArrayType;
+use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
@@ -29,7 +32,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
-final class FacebookSendButtonBlockService extends BaseFacebookSocialPluginsBlockService
+final class FacebookSendButtonBlockService extends BaseFacebookSocialPluginsBlockService implements EditableBlockService
 {
     public function configureSettings(OptionsResolver $resolver): void
     {
@@ -42,9 +45,14 @@ final class FacebookSendButtonBlockService extends BaseFacebookSocialPluginsBloc
         ]);
     }
 
-    public function buildEditForm(FormMapper $formMapper, BlockInterface $block): void
+    public function configureCreateForm(FormMapper $form, BlockInterface $block): void
     {
-        $formMapper->add('settings', ImmutableArrayType::class, [
+        $this->configureEditForm($form, $block);
+    }
+
+    public function configureEditForm(FormMapper $form, BlockInterface $block): void
+    {
+        $form->add('settings', ImmutableArrayType::class, [
             'keys' => [
                 ['url', UrlType::class, [
                     'required' => false,
@@ -68,9 +76,13 @@ final class FacebookSendButtonBlockService extends BaseFacebookSocialPluginsBloc
         ]);
     }
 
-    public function getBlockMetadata($code = null)
+    public function validate(ErrorElement $errorElement, BlockInterface $block): void
     {
-        return new Metadata($this->getName(), (null !== $code ? $code : $this->getName()), false, 'SonataSeoBundle', [
+    }
+
+    public function getMetadata(): MetadataInterface
+    {
+        return new Metadata('sonata.seo.block.facebook.send_button', null, null, 'SonataSeoBundle', [
             'class' => 'fa fa-facebook-official',
         ]);
     }

--- a/src/Block/Social/FacebookShareButtonBlockService.php
+++ b/src/Block/Social/FacebookShareButtonBlockService.php
@@ -13,10 +13,13 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\Block\Social;
 
-use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
+use Sonata\BlockBundle\Meta\Metadata;
+use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
-use Sonata\CoreBundle\Model\Metadata;
+use Sonata\Form\Type\ImmutableArrayType;
+use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
@@ -29,7 +32,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
-final class FacebookShareButtonBlockService extends BaseFacebookSocialPluginsBlockService
+final class FacebookShareButtonBlockService extends BaseFacebookSocialPluginsBlockService implements EditableBlockService
 {
     /**
      * @var string[]
@@ -53,9 +56,14 @@ final class FacebookShareButtonBlockService extends BaseFacebookSocialPluginsBlo
         ]);
     }
 
-    public function buildEditForm(FormMapper $formMapper, BlockInterface $block): void
+    public function configureCreateForm(FormMapper $form, BlockInterface $block): void
     {
-        $formMapper->add('settings', ImmutableArrayType::class, [
+        $this->configureEditForm($form, $block);
+    }
+
+    public function configureEditForm(FormMapper $form, BlockInterface $block): void
+    {
+        $form->add('settings', ImmutableArrayType::class, [
             'keys' => [
                 ['url', UrlType::class, [
                     'required' => false,
@@ -75,9 +83,13 @@ final class FacebookShareButtonBlockService extends BaseFacebookSocialPluginsBlo
         ]);
     }
 
-    public function getBlockMetadata($code = null)
+    public function validate(ErrorElement $errorElement, BlockInterface $block): void
     {
-        return new Metadata($this->getName(), (null !== $code ? $code : $this->getName()), false, 'SonataSeoBundle', [
+    }
+
+    public function getMetadata(): MetadataInterface
+    {
+        return new Metadata('sonata.seo.block.facebook.share_button', null, null, 'SonataSeoBundle', [
             'class' => 'fa fa-facebook-official',
         ]);
     }

--- a/src/Block/Social/PinterestPinButtonBlockService.php
+++ b/src/Block/Social/PinterestPinButtonBlockService.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\Block\Social;
 
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
+use Sonata\BlockBundle\Meta\Metadata;
+use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
-use Sonata\CoreBundle\Model\Metadata;
+use Sonata\Form\Type\ImmutableArrayType;
+use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -33,7 +36,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
-final class PinterestPinButtonBlockService extends AbstractAdminBlockService
+final class PinterestPinButtonBlockService extends AbstractBlockService implements EditableBlockService
 {
     public function configureSettings(OptionsResolver $resolver): void
     {
@@ -47,9 +50,14 @@ final class PinterestPinButtonBlockService extends AbstractAdminBlockService
         ]);
     }
 
-    public function buildEditForm(FormMapper $formMapper, BlockInterface $block): void
+    public function configureCreateForm(FormMapper $form, BlockInterface $block): void
     {
-        $formMapper->add('settings', ImmutableArrayType::class, [
+        $this->configureEditForm($form, $block);
+    }
+
+    public function configureEditForm(FormMapper $form, BlockInterface $block): void
+    {
+        $form->add('settings', ImmutableArrayType::class, [
             'keys' => [
                 ['url', UrlType::class, [
                     'required' => false,
@@ -80,7 +88,11 @@ final class PinterestPinButtonBlockService extends AbstractAdminBlockService
         ]);
     }
 
-    public function execute(BlockContextInterface $blockContext, Response $response = null)
+    public function validate(ErrorElement $errorElement, BlockInterface $block): void
+    {
+    }
+
+    public function execute(BlockContextInterface $blockContext, Response $response = null): Response
     {
         $block = $blockContext->getBlock();
         $settings = array_merge($blockContext->getSettings(), $block->getSettings());
@@ -91,10 +103,10 @@ final class PinterestPinButtonBlockService extends AbstractAdminBlockService
         ], $response);
     }
 
-    public function getBlockMetadata($code = null)
+    public function getMetadata(): MetadataInterface
     {
-        return new Metadata($this->getName(), (null !== $code ? $code : $this->getName()), false, 'SonataSeoBundle', [
-            'class' => 'fa fa-pinterest-p',
+        return new Metadata('sonata.seo.block.pinterest.pin_button', null, null, 'SonataSeoBundle', [
+            'class' => 'fa fa-envelope-o',
         ]);
     }
 }

--- a/src/Block/Social/TwitterFollowButtonBlockService.php
+++ b/src/Block/Social/TwitterFollowButtonBlockService.php
@@ -13,10 +13,13 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\Block\Social;
 
-use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
+use Sonata\BlockBundle\Meta\Metadata;
+use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
-use Sonata\CoreBundle\Model\Metadata;
+use Sonata\Form\Type\ImmutableArrayType;
+use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -29,7 +32,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
-final class TwitterFollowButtonBlockService extends BaseTwitterButtonBlockService
+final class TwitterFollowButtonBlockService extends BaseTwitterButtonBlockService implements EditableBlockService
 {
     public function configureSettings(OptionsResolver $resolver): void
     {
@@ -43,9 +46,14 @@ final class TwitterFollowButtonBlockService extends BaseTwitterButtonBlockServic
         ]);
     }
 
-    public function buildEditForm(FormMapper $formMapper, BlockInterface $block): void
+    public function configureCreateForm(FormMapper $form, BlockInterface $block): void
     {
-        $formMapper->add('settings', ImmutableArrayType::class, [
+        $this->configureEditForm($form, $block);
+    }
+
+    public function configureEditForm(FormMapper $form, BlockInterface $block): void
+    {
+        $form->add('settings', ImmutableArrayType::class, [
             'keys' => [
                 ['user', TextType::class, [
                     'required' => true,
@@ -73,9 +81,13 @@ final class TwitterFollowButtonBlockService extends BaseTwitterButtonBlockServic
         ]);
     }
 
-    public function getBlockMetadata($code = null)
+    public function validate(ErrorElement $errorElement, BlockInterface $block): void
     {
-        return new Metadata($this->getName(), (null !== $code ? $code : $this->getName()), false, 'SonataSeoBundle', [
+    }
+
+    public function getMetadata(): MetadataInterface
+    {
+        return new Metadata('sonata.seo.block.twitter.follow_button', null, null, 'SonataSeoBundle', [
             'class' => 'fa fa-twitter',
         ]);
     }

--- a/src/Block/Social/TwitterHashtagButtonBlockService.php
+++ b/src/Block/Social/TwitterHashtagButtonBlockService.php
@@ -13,10 +13,13 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\Block\Social;
 
-use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
+use Sonata\BlockBundle\Meta\Metadata;
+use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
-use Sonata\CoreBundle\Model\Metadata;
+use Sonata\Form\Type\ImmutableArrayType;
+use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -30,7 +33,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
-final class TwitterHashtagButtonBlockService extends BaseTwitterButtonBlockService
+final class TwitterHashtagButtonBlockService extends BaseTwitterButtonBlockService implements EditableBlockService
 {
     public function configureSettings(OptionsResolver $resolver): void
     {
@@ -46,9 +49,14 @@ final class TwitterHashtagButtonBlockService extends BaseTwitterButtonBlockServi
         ]);
     }
 
-    public function buildEditForm(FormMapper $formMapper, BlockInterface $block): void
+    public function configureCreateForm(FormMapper $form, BlockInterface $block): void
     {
-        $formMapper->add('settings', ImmutableArrayType::class, [
+        $this->configureEditForm($form, $block);
+    }
+
+    public function configureEditForm(FormMapper $form, BlockInterface $block): void
+    {
+        $form->add('settings', ImmutableArrayType::class, [
             'keys' => [
                 ['hashtag', TextType::class, [
                     'required' => true,
@@ -84,9 +92,13 @@ final class TwitterHashtagButtonBlockService extends BaseTwitterButtonBlockServi
         ]);
     }
 
-    public function getBlockMetadata($code = null)
+    public function validate(ErrorElement $errorElement, BlockInterface $block): void
     {
-        return new Metadata($this->getName(), (null !== $code ? $code : $this->getName()), false, 'SonataSeoBundle', [
+    }
+
+    public function getMetadata(): MetadataInterface
+    {
+        return new Metadata('sonata.seo.block.twitter.hashtag_button', null, null, 'SonataSeoBundle', [
             'class' => 'fa fa-twitter',
         ]);
     }

--- a/src/Block/Social/TwitterMentionButtonBlockService.php
+++ b/src/Block/Social/TwitterMentionButtonBlockService.php
@@ -13,10 +13,13 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\Block\Social;
 
-use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
+use Sonata\BlockBundle\Meta\Metadata;
+use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
-use Sonata\CoreBundle\Model\Metadata;
+use Sonata\Form\Type\ImmutableArrayType;
+use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -29,7 +32,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
-final class TwitterMentionButtonBlockService extends BaseTwitterButtonBlockService
+final class TwitterMentionButtonBlockService extends BaseTwitterButtonBlockService implements EditableBlockService
 {
     public function configureSettings(OptionsResolver $resolver): void
     {
@@ -44,9 +47,14 @@ final class TwitterMentionButtonBlockService extends BaseTwitterButtonBlockServi
         ]);
     }
 
-    public function buildEditForm(FormMapper $formMapper, BlockInterface $block): void
+    public function configureCreateForm(FormMapper $form, BlockInterface $block): void
     {
-        $formMapper->add('settings', ImmutableArrayType::class, [
+        $this->configureEditForm($form, $block);
+    }
+
+    public function configureEditForm(FormMapper $form, BlockInterface $block): void
+    {
+        $form->add('settings', ImmutableArrayType::class, [
             'keys' => [
                 ['user', TextType::class, [
                     'required' => true,
@@ -78,9 +86,13 @@ final class TwitterMentionButtonBlockService extends BaseTwitterButtonBlockServi
         ]);
     }
 
-    public function getBlockMetadata($code = null)
+    public function validate(ErrorElement $errorElement, BlockInterface $block): void
     {
-        return new Metadata($this->getName(), (null !== $code ? $code : $this->getName()), false, 'SonataSeoBundle', [
+    }
+
+    public function getMetadata(): MetadataInterface
+    {
+        return new Metadata('sonata.seo.block.twitter.mention_button', null, null, 'SonataSeoBundle', [
             'class' => 'fa fa-twitter',
         ]);
     }

--- a/src/Block/Social/TwitterShareButtonBlockService.php
+++ b/src/Block/Social/TwitterShareButtonBlockService.php
@@ -13,10 +13,13 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\Block\Social;
 
-use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
+use Sonata\BlockBundle\Meta\Metadata;
+use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
-use Sonata\CoreBundle\Model\Metadata;
+use Sonata\Form\Type\ImmutableArrayType;
+use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -30,7 +33,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
-final class TwitterShareButtonBlockService extends BaseTwitterButtonBlockService
+final class TwitterShareButtonBlockService extends BaseTwitterButtonBlockService implements EditableBlockService
 {
     public function configureSettings(OptionsResolver $resolver): void
     {
@@ -48,9 +51,14 @@ final class TwitterShareButtonBlockService extends BaseTwitterButtonBlockService
         ]);
     }
 
-    public function buildEditForm(FormMapper $formMapper, BlockInterface $block): void
+    public function configureCreateForm(FormMapper $form, BlockInterface $block): void
     {
-        $formMapper->add('settings', ImmutableArrayType::class, [
+        $this->configureEditForm($form, $block);
+    }
+
+    public function configureEditForm(FormMapper $form, BlockInterface $block): void
+    {
+        $form->add('settings', ImmutableArrayType::class, [
             'keys' => [
                 ['url', UrlType::class, [
                     'required' => false,
@@ -94,9 +102,13 @@ final class TwitterShareButtonBlockService extends BaseTwitterButtonBlockService
         ]);
     }
 
-    public function getBlockMetadata($code = null)
+    public function validate(ErrorElement $errorElement, BlockInterface $block): void
     {
-        return new Metadata($this->getName(), (null !== $code ? $code : $this->getName()), false, 'SonataSeoBundle', [
+    }
+
+    public function getMetadata(): MetadataInterface
+    {
+        return new Metadata('sonata.seo.block.twitter.share_button', null, null, 'SonataSeoBundle', [
             'class' => 'fa fa-twitter',
         ]);
     }

--- a/src/Resources/config/blocks.xml
+++ b/src/Resources/config/blocks.xml
@@ -21,59 +21,49 @@
         <!-- Email buttons -->
         <service id="sonata.seo.block.email.share_button" class="%sonata.seo.block.email.share_button.class%" public="true">
             <tag name="sonata.block"/>
-            <argument>sonata.seo.block.email.share_button</argument>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
         </service>
         <!-- Email buttons -->
         <!-- Facebook Social Plugins -->
         <service id="sonata.seo.block.facebook.like_box" class="%sonata.seo.block.facebook.like_box.class%" public="true">
             <tag name="sonata.block"/>
-            <argument>sonata.seo.block.facebook.like_box</argument>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
         </service>
         <service id="sonata.seo.block.facebook.like_button" class="%sonata.seo.block.facebook.like_button.class%" public="true">
             <tag name="sonata.block"/>
-            <argument>sonata.seo.block.facebook.like_button</argument>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
         </service>
         <service id="sonata.seo.block.facebook.send_button" class="%sonata.seo.block.facebook.send_button.class%" public="true">
             <tag name="sonata.block"/>
-            <argument>sonata.seo.block.facebook.send_button</argument>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
         </service>
         <service id="sonata.seo.block.facebook.share_button" class="%sonata.seo.block.facebook.share_button.class%" public="true">
             <tag name="sonata.block"/>
-            <argument>sonata.seo.block.facebook.share_button</argument>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
         </service>
         <!-- Facebook Social Plugins -->
         <!-- Twitter buttons -->
         <service id="sonata.seo.block.twitter.share_button" class="%sonata.seo.block.twitter.share_button.class%" public="true">
             <tag name="sonata.block"/>
-            <argument>sonata.seo.block.twitter.share_button</argument>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
         </service>
         <service id="sonata.seo.block.twitter.follow_button" class="%sonata.seo.block.twitter.follow_button.class%" public="true">
             <tag name="sonata.block"/>
-            <argument>sonata.seo.block.twitter.follow_button</argument>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
         </service>
         <service id="sonata.seo.block.twitter.hashtag_button" class="%sonata.seo.block.twitter.hashtag_button.class%" public="true">
             <tag name="sonata.block"/>
-            <argument>sonata.seo.block.twitter.hashtag_button</argument>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
         </service>
         <service id="sonata.seo.block.twitter.mention_button" class="%sonata.seo.block.twitter.mention_button.class%" public="true">
             <tag name="sonata.block"/>
-            <argument>sonata.seo.block.twitter.mention_button</argument>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
         </service>
         <!-- Twitter buttons -->
         <!-- Twitter embed -->
         <service id="sonata.seo.block.twitter.embed" class="%sonata.seo.block.twitter.embed.class%" public="true">
             <tag name="sonata.block"/>
-            <argument>sonata.seo.block.twitter.embed</argument>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
             <argument type="service" id="sonata.seo.http.client" on-invalid="null"/>
             <argument type="service" id="sonata.seo.http.message_factory" on-invalid="null"/>
         </service>
@@ -81,17 +71,14 @@
         <!-- Pinterest buttons -->
         <service id="sonata.seo.block.pinterest.pin_button" class="%sonata.seo.block.pinterest.pin_button.class%" public="true">
             <tag name="sonata.block"/>
-            <argument>sonata.seo.block.pinterest.pin_button</argument>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
         </service>
         <!-- Pinterest buttons -->
         <!-- Breadcrumb -->
         <service id="sonata.seo.block.breadcrumb.homepage" class="%sonata.seo.block.breadcrumb.homepage.class%" public="true">
-            <tag name="sonata.breadcrumb"/>
+            <tag name="sonata.breadcrumb" context="homepage"/>
             <tag name="sonata.block"/>
-            <argument>homepage</argument>
-            <argument>sonata.seo.block.breadcrumb.homepage</argument>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
             <argument type="service" id="knp_menu.menu_provider"/>
             <argument type="service" id="knp_menu.factory"/>
         </service>

--- a/tests/Block/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Block/Breadcrumb/BreadcrumbTest.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace Sonata\SeoBundle\Tests\Block\Breadcrumb;
 
 use Knp\Menu\FactoryInterface;
-use Knp\Menu\Provider\MenuProviderInterface;
+use Sonata\BlockBundle\Block\Service\MenuBlockService;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
 use Sonata\SeoBundle\Block\Breadcrumb\BaseBreadcrumbMenuBlockService;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Twig\Environment;
 
 final class BreadcrumbMenuBlockService_Test extends BaseBreadcrumbMenuBlockService
 {
@@ -31,10 +31,8 @@ final class BreadcrumbTest extends BlockServiceTestCase
     public function testBlockService(): void
     {
         $blockService = new BreadcrumbMenuBlockService_Test(
-            'context',
-            'name',
-            $this->createMock(EngineInterface::class),
-            $this->createMock(MenuProviderInterface::class),
+            $this->createMock(Environment::class),
+            $this->createMock(MenuBlockService::class),
             $this->createMock(FactoryInterface::class)
         );
 

--- a/tests/Block/Social/FacebookLikeBoxBlockServiceTest.php
+++ b/tests/Block/Social/FacebookLikeBoxBlockServiceTest.php
@@ -13,20 +13,19 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\Tests\Block\Social;
 
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContext;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Model\Block;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
-use Sonata\BlockBundle\Util\OptionsResolver;
 use Sonata\SeoBundle\Block\Social\FacebookLikeBoxBlockService;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class FacebookLikeBoxBlockServiceTest extends BlockServiceTestCase
 {
     public function testService(): void
     {
         $service = new FacebookLikeBoxBlockService(
-            'sonata.block.service.facebook.like_box',
-            $this->templating
+            $this->twig
         );
 
         $block = new Block();
@@ -43,25 +42,25 @@ final class FacebookLikeBoxBlockServiceTest extends BlockServiceTestCase
         ]);
 
         $optionResolver = new OptionsResolver();
-        $service->setDefaultSettings($optionResolver);
+        $service->configureSettings($optionResolver);
 
         $blockContext = new BlockContext($block, $optionResolver->resolve($block->getSettings()));
 
         $formMapper = $this->createMock(FormMapper::class, [], [], '', false);
         $formMapper->expects($this->exactly(2))->method('add');
 
-        $service->buildCreateForm($formMapper, $block);
-        $service->buildEditForm($formMapper, $block);
+        $service->configureCreateForm($formMapper, $block);
+        $service->configureEditForm($formMapper, $block);
 
         $service->execute($blockContext);
 
-        $this->assertSame('url_setting', $this->templating->parameters['settings']['url']);
-        $this->assertSame('width_setting', $this->templating->parameters['settings']['width']);
-        $this->assertSame('height_setting', $this->templating->parameters['settings']['height']);
-        $this->assertSame('colorscheme_setting', $this->templating->parameters['settings']['colorscheme']);
-        $this->assertSame('show_faces_setting', $this->templating->parameters['settings']['show_faces']);
-        $this->assertSame('show_header_setting', $this->templating->parameters['settings']['show_header']);
-        $this->assertSame('show_posts_setting', $this->templating->parameters['settings']['show_posts']);
-        $this->assertSame('show_border_setting', $this->templating->parameters['settings']['show_border']);
+        $this->assertSame('url_setting', $this->twig->parameters['settings']['url']);
+        $this->assertSame('width_setting', $this->twig->parameters['settings']['width']);
+        $this->assertSame('height_setting', $this->twig->parameters['settings']['height']);
+        $this->assertSame('colorscheme_setting', $this->twig->parameters['settings']['colorscheme']);
+        $this->assertSame('show_faces_setting', $this->twig->parameters['settings']['show_faces']);
+        $this->assertSame('show_header_setting', $this->twig->parameters['settings']['show_header']);
+        $this->assertSame('show_posts_setting', $this->twig->parameters['settings']['show_posts']);
+        $this->assertSame('show_border_setting', $this->twig->parameters['settings']['show_border']);
     }
 }

--- a/tests/Block/Social/FacebookLikeButtonBlockServiceTest.php
+++ b/tests/Block/Social/FacebookLikeButtonBlockServiceTest.php
@@ -13,20 +13,19 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\Tests\Block\Social;
 
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContext;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Model\Block;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
-use Sonata\BlockBundle\Util\OptionsResolver;
 use Sonata\SeoBundle\Block\Social\FacebookLikeButtonBlockService;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class FacebookLikeButtonBlockServiceTest extends BlockServiceTestCase
 {
     public function testService(): void
     {
         $service = new FacebookLikeButtonBlockService(
-            'sonata.block.service.facebook.like_button',
-            $this->templating
+            $this->twig
         );
 
         $block = new Block();
@@ -42,24 +41,24 @@ final class FacebookLikeButtonBlockServiceTest extends BlockServiceTestCase
         ]);
 
         $optionResolver = new OptionsResolver();
-        $service->setDefaultSettings($optionResolver);
+        $service->configureSettings($optionResolver);
 
         $blockContext = new BlockContext($block, $optionResolver->resolve($block->getSettings()));
 
         $formMapper = $this->createMock(FormMapper::class, [], [], '', false);
         $formMapper->expects($this->exactly(2))->method('add');
 
-        $service->buildCreateForm($formMapper, $block);
-        $service->buildEditForm($formMapper, $block);
+        $service->configureCreateForm($formMapper, $block);
+        $service->configureEditForm($formMapper, $block);
 
         $service->execute($blockContext);
 
-        $this->assertSame('url_setting', $this->templating->parameters['settings']['url']);
-        $this->assertSame('width_setting', $this->templating->parameters['settings']['width']);
-        $this->assertSame('show_faces_setting', $this->templating->parameters['settings']['show_faces']);
-        $this->assertSame('share_setting', $this->templating->parameters['settings']['share']);
-        $this->assertSame('layout_setting', $this->templating->parameters['settings']['layout']);
-        $this->assertSame('colorscheme_setting', $this->templating->parameters['settings']['colorscheme']);
-        $this->assertSame('action_setting', $this->templating->parameters['settings']['action']);
+        $this->assertSame('url_setting', $this->twig->parameters['settings']['url']);
+        $this->assertSame('width_setting', $this->twig->parameters['settings']['width']);
+        $this->assertSame('show_faces_setting', $this->twig->parameters['settings']['show_faces']);
+        $this->assertSame('share_setting', $this->twig->parameters['settings']['share']);
+        $this->assertSame('layout_setting', $this->twig->parameters['settings']['layout']);
+        $this->assertSame('colorscheme_setting', $this->twig->parameters['settings']['colorscheme']);
+        $this->assertSame('action_setting', $this->twig->parameters['settings']['action']);
     }
 }

--- a/tests/Block/Social/FacebookSendButtonBlockServiceTest.php
+++ b/tests/Block/Social/FacebookSendButtonBlockServiceTest.php
@@ -13,20 +13,19 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\Tests\Block\Social;
 
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContext;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Model\Block;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
-use Sonata\BlockBundle\Util\OptionsResolver;
 use Sonata\SeoBundle\Block\Social\FacebookSendButtonBlockService;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class FacebookSendButtonBlockServiceTest extends BlockServiceTestCase
 {
     public function testService(): void
     {
         $service = new FacebookSendButtonBlockService(
-            'sonata.block.service.facebook.send_button',
-            $this->templating
+            $this->twig
         );
 
         $block = new Block();
@@ -39,21 +38,21 @@ final class FacebookSendButtonBlockServiceTest extends BlockServiceTestCase
         ]);
 
         $optionResolver = new OptionsResolver();
-        $service->setDefaultSettings($optionResolver);
+        $service->configureSettings($optionResolver);
 
         $blockContext = new BlockContext($block, $optionResolver->resolve($block->getSettings()));
 
         $formMapper = $this->createMock(FormMapper::class, [], [], '', false);
         $formMapper->expects($this->exactly(2))->method('add');
 
-        $service->buildCreateForm($formMapper, $block);
-        $service->buildEditForm($formMapper, $block);
+        $service->configureCreateForm($formMapper, $block);
+        $service->configureEditForm($formMapper, $block);
 
         $service->execute($blockContext);
 
-        $this->assertSame('url_setting', $this->templating->parameters['settings']['url']);
-        $this->assertSame('width_setting', $this->templating->parameters['settings']['width']);
-        $this->assertSame('height_setting', $this->templating->parameters['settings']['height']);
-        $this->assertSame('colorscheme_setting', $this->templating->parameters['settings']['colorscheme']);
+        $this->assertSame('url_setting', $this->twig->parameters['settings']['url']);
+        $this->assertSame('width_setting', $this->twig->parameters['settings']['width']);
+        $this->assertSame('height_setting', $this->twig->parameters['settings']['height']);
+        $this->assertSame('colorscheme_setting', $this->twig->parameters['settings']['colorscheme']);
     }
 }

--- a/tests/Block/Social/FacebookShareButtonBlockServiceTest.php
+++ b/tests/Block/Social/FacebookShareButtonBlockServiceTest.php
@@ -13,20 +13,19 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\Tests\Block\Social;
 
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContext;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Model\Block;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
-use Sonata\BlockBundle\Util\OptionsResolver;
 use Sonata\SeoBundle\Block\Social\FacebookShareButtonBlockService;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class FacebookShareButtonBlockServiceTest extends BlockServiceTestCase
 {
     public function testService(): void
     {
         $service = new FacebookShareButtonBlockService(
-            'sonata.block.service.facebook.share_button',
-            $this->templating
+            $this->twig
         );
 
         $block = new Block();
@@ -38,20 +37,20 @@ final class FacebookShareButtonBlockServiceTest extends BlockServiceTestCase
         ]);
 
         $optionResolver = new OptionsResolver();
-        $service->setDefaultSettings($optionResolver);
+        $service->configureSettings($optionResolver);
 
         $blockContext = new BlockContext($block, $optionResolver->resolve($block->getSettings()));
 
         $formMapper = $this->createMock(FormMapper::class, [], [], '', false);
         $formMapper->expects($this->exactly(2))->method('add');
 
-        $service->buildCreateForm($formMapper, $block);
-        $service->buildEditForm($formMapper, $block);
+        $service->configureCreateForm($formMapper, $block);
+        $service->configureEditForm($formMapper, $block);
 
         $service->execute($blockContext);
 
-        $this->assertSame('url_setting', $this->templating->parameters['settings']['url']);
-        $this->assertSame('width_setting', $this->templating->parameters['settings']['width']);
-        $this->assertSame('layout_setting', $this->templating->parameters['settings']['layout']);
+        $this->assertSame('url_setting', $this->twig->parameters['settings']['url']);
+        $this->assertSame('width_setting', $this->twig->parameters['settings']['width']);
+        $this->assertSame('layout_setting', $this->twig->parameters['settings']['layout']);
     }
 }

--- a/tests/Block/Social/TwitterEmbedTweetBlockServiceTest.php
+++ b/tests/Block/Social/TwitterEmbedTweetBlockServiceTest.php
@@ -16,7 +16,7 @@ namespace Sonata\SeoBundle\Tests\Block\Social;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
 use Sonata\SeoBundle\Block\Social\TwitterEmbedTweetBlockService;
 use Sonata\SeoBundle\Tests\Fixtures\Block\TwitterEmbedTweetBSTest;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Twig\Environment;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -33,7 +33,7 @@ final class TwitterEmbedTweetBlockServiceTest extends BlockServiceTestCase
 
         $expected = sprintf('%s?%s', TwitterEmbedTweetBlockService::TWITTER_OEMBED_URI, 'align=bar&url=tweeeeeeeet');
 
-        $blockService = new TwitterEmbedTweetBSTest('', $this->createMock(EngineInterface::class));
+        $blockService = new TwitterEmbedTweetBSTest($this->createMock(Environment::class));
         $this->assertSame($expected, $blockService->publicBuildUri(true, $settings));
 
         $expected = sprintf('%s?%s', TwitterEmbedTweetBlockService::TWITTER_OEMBED_URI, 'align=bar&id=tweeeeeeeet');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Make optional dependency for sonata block a required dependency.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is not BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataSeoBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `sonata-project/block-bundle` dependency

### Changed
- Adopt new block service interfaces
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
-->

## To do
- [x] New form release    
- [ ] Update the tests
- [ ] Create `MenuBlock` interface in BlockBundle