### PR TITLE
Deprecate Guzzle with psr http-client

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,6 +1,13 @@
 UPGRADE 2.x
 ===========
 
+## TwitterEmbedTweetBlockService uses psr/http-client
+
+The `Guzzle` dependency was removed and replaced with abstract `http-client` interface, so you can choose your preferred
+client implementation. If you have extended the `TwitterEmbedTweetBlockService` class, you need to adjust the
+constructor signature.
+
+
 UPGRADE FROM 2.2 to 2.3
 =======================
 
@@ -23,6 +30,6 @@ UPGRADE FROM 2.0 to 2.1
 
 ### Tests
 
-All files under the ``Tests`` directory are now correctly handled as internal test classes. 
-You can't extend them anymore, because they are only loaded when running internal tests. 
+All files under the ``Tests`` directory are now correctly handled as internal test classes.
+You can't extend them anymore, because they are only loaded when running internal tests.
 More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,8 @@
     ],
     "require": {
         "php": "^7.1",
+        "psr/http-client": "^1.0",
+        "psr/http-message": "^1.0",
         "sonata-project/exporter": "^1.11 || ^2.0",
         "symfony/config": "^3.4 || ^4.2 || ^5.0",
         "symfony/dependency-injection": "^3.4 || ^4.2 || ^5.0",
@@ -35,19 +37,21 @@
         "sonata-project/block-bundle": "<3.11"
     },
     "require-dev": {
-        "guzzle/guzzle": "^3.8",
+        "guzzlehttp/guzzle": "^6.0",
+        "nyholm/psr7": "^1.2",
         "sonata-project/admin-bundle": "^3.31",
         "sonata-project/block-bundle": "^3.11",
         "sonata-project/core-bundle": "^3.9",
         "symfony/console": "^3.4 || ^4.2 || ^5.0",
         "symfony/filesystem": "^3.4 || ^4.2 || ^5.0",
         "symfony/finder": "^3.4 || ^4.2 || ^5.0",
+        "symfony/http-client": "^4.4 || ^5.0",
         "symfony/phpunit-bridge": "^4.1 || ^5.0",
         "symfony/yaml": "^3.4 || ^4.2 || ^5.0"
     },
     "suggest": {
-        "guzzle/guzzle": "3.*",
-        "knplabs/knp-menu-bundle": "Used by the BreadcrumbMenuBuilder"
+        "knplabs/knp-menu-bundle": "Used by the BreadcrumbMenuBuilder",
+        "symfony/http-client": "Symfony client implementation for TwitterEmbedTweetBlockService"
     },
     "config": {
         "sort-packages": true

--- a/docs/reference/social_blocks.rst
+++ b/docs/reference/social_blocks.rst
@@ -49,5 +49,11 @@ The ``sonata.seo.block.twitter.embed`` allows you to embed a tweet by giving its
 or embed content. Please refer to `Embedded Tweets doc <https://dev.twitter.com/docs/embedded-tweets>`_
 and `OEmbed API doc <https://dev.twitter.com/docs/api/1/get/statuses/oembed>`_ for a full understanding.
 
-The block service allows you to ask the API if you've given an ID or a URL (you'll need to install the
-Guzzle library for this: ``composer require guzzle/guzzle``).
+The block service allows you to ask the API if you've given an ID or a URL .
+
+You'll need to install a ``psr/http-client`` (e.g. ``symfony/http-client``) and a ``psr/http-message`` (e.g ``nyholm/psr7``)
+to request the Twitter API:
+
+.. code-block:: bash
+
+    composer require symfony/http-client nyholm/psr7

--- a/src/Block/Social/TwitterEmbedTweetBlockService.php
+++ b/src/Block/Social/TwitterEmbedTweetBlockService.php
@@ -13,12 +13,16 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\Block\Social;
 
-use Guzzle\Http\Exception\CurlException;
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
@@ -41,36 +45,32 @@ class TwitterEmbedTweetBlockService extends BaseTwitterButtonBlockService
     public const TWEET_ID_PATTERN = '%^([0-9]*)$%';
 
     /**
-     * {@inheritdoc}
+     * @var ClientInterface|null
      */
+    private $httpClient;
+
+    /**
+     * @var RequestFactoryInterface|null
+     */
+    private $messageFactory;
+
+    public function __construct(
+        ?string $name,
+        EngineInterface $templating,
+        ClientInterface $httpClient = null,
+        RequestFactoryInterface $messageFactory = null
+    ) {
+        parent::__construct($name, $templating);
+
+        $this->httpClient = $httpClient;
+        $this->messageFactory = $messageFactory;
+    }
+
     public function execute(BlockContextInterface $blockContext, Response $response = null)
     {
-        $tweet = $blockContext->getSetting('tweet');
-
-        if (($uriMatched = preg_match(self::TWEET_URL_PATTERN, $tweet))
-            || preg_match(self::TWEET_ID_PATTERN, $tweet)) {
-            // We matched an URL or an ID, we'll need to ask the API
-            if (false === class_exists('Guzzle\Http\Client')) {
-                throw new \RuntimeException('The guzzle http client library is required to call the Twitter API. Make sure to add guzzle/guzzle to your composer.json.');
-            }
-
-            // TODO cache API result
-            $client = new \Guzzle\Http\Client();
-            $client->setConfig(['curl.options' => [CURLOPT_CONNECTTIMEOUT_MS => 1000]]);
-
-            try {
-                $request = $client->get($this->buildUri($uriMatched, $blockContext->getSettings()));
-                $apiTweet = json_decode($request->send()->getBody(true), true);
-
-                $tweet = $apiTweet['html'];
-            } catch (CurlException $e) {
-                // log error
-            }
-        }
-
         return $this->renderResponse($blockContext->getTemplate(), [
             'block' => $blockContext->getBlock(),
-            'tweet' => $tweet,
+            'tweet' => $this->loadTweet($blockContext),
         ], $response);
     }
 
@@ -208,5 +208,65 @@ class TwitterEmbedTweetBlockService extends BaseTwitterButtonBlockService
         }
 
         return sprintf('%s?%s', self::TWITTER_OEMBED_URI, implode('&', $parameters));
+    }
+
+    /**
+     * Loads twitter tweet.
+     */
+    private function loadTweet(BlockContextInterface $blockContext): ?string
+    {
+        $uriMatched = preg_match(self::TWEET_URL_PATTERN, $blockContext->getSetting('tweet'));
+
+        if (!$uriMatched || !preg_match(self::TWEET_ID_PATTERN, $blockContext->getSetting('tweet'))) {
+            return null;
+        }
+
+        if (null !== $this->httpClient && null !== $this->messageFactory) {
+            try {
+                $response = $this->httpClient->sendRequest(
+                    $this->messageFactory->createRequest(
+                        'GET',
+                        $this->buildUri($uriMatched, $blockContext->getSettings())
+                    )
+                );
+            } catch (ClientExceptionInterface $e) {
+                // log error
+                return null;
+            }
+
+            $apiTweet = json_decode($response->getBody(), true);
+
+            return $apiTweet['html'];
+        }
+
+        // NEXT_MAJOR: Remove the old guzzle implementation
+
+        // We matched an URL or an ID, we'll need to ask the API
+        if (false === class_exists('GuzzleHttp\Client')) {
+            throw new \RuntimeException(
+                'The guzzle http client library is required to call the Twitter API.'.
+                'Make sure to add psr/http-client or guzzlehttp/guzzle to your composer.json.'
+            );
+        }
+
+        @trigger_error(
+            'The direct Guzzle implementation is deprecated since 2.x and will be removed with the next major release.',
+            E_USER_DEPRECATED
+        );
+
+        // TODO cache API result
+        $client = new \GuzzleHttp\Client();
+        $client->setConfig(['curl.options' => [CURLOPT_CONNECTTIMEOUT_MS => 1000]]);
+
+        try {
+            $request = $client->get($this->buildUri($uriMatched, $blockContext->getSettings()));
+            $apiTweet = json_decode($request->send()->getBody(true), true);
+
+            return $apiTweet['html'];
+        } catch (GuzzleException $e) {
+            // log error
+            return null;
+        }
+        // END NEXT_MAJOR
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -75,6 +76,28 @@ class Configuration implements ConfigurationInterface
             ->end()
         ;
 
+        $this->addHttpClientSection($rootNode);
+
         return $treeBuilder;
+    }
+
+    private function addHttpClientSection(ArrayNodeDefinition $node): void
+    {
+        $node
+            ->children()
+                ->arrayNode('http')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('client')
+                            ->defaultNull()
+                            ->info('Alias of the http client.')
+                        ->end()
+                        ->scalarNode('message_factory')
+                            ->defaultNull()
+                            ->info('Alias of the message factory.')
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
     }
 }

--- a/src/DependencyInjection/SonataSeoExtension.php
+++ b/src/DependencyInjection/SonataSeoExtension.php
@@ -48,6 +48,7 @@ class SonataSeoExtension extends Extension
 
         $this->configureSeoPage($config['page'], $container);
         $this->configureSitemap($config['sitemap'], $container);
+        $this->configureHttpClient($container, $config['http']);
 
         $container->getDefinition('sonata.seo.twig.extension')
             ->replaceArgument(1, $config['encoding']);
@@ -154,5 +155,15 @@ class SonataSeoExtension extends Extension
         }
 
         return $config;
+    }
+
+    private function configureHttpClient(ContainerBuilder $container, array $config): void
+    {
+        if (null === $config['client'] || null === $config['message_factory']) {
+            return;
+        }
+
+        $container->setAlias('sonata.seo.http.client', $config['client']);
+        $container->setAlias('sonata.seo.http.message_factory', $config['message_factory']);
     }
 }

--- a/src/Resources/config/blocks.xml
+++ b/src/Resources/config/blocks.xml
@@ -74,6 +74,8 @@
             <tag name="sonata.block"/>
             <argument>sonata.seo.block.twitter.embed</argument>
             <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="sonata.seo.http.client" on-invalid="null"/>
+            <argument type="service" id="sonata.seo.http.message_factory" on-invalid="null"/>
         </service>
         <!-- Twitter embed -->
         <!-- Pinterest buttons -->

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -35,6 +35,10 @@ class ConfigurationTest extends TestCase
                 'doctrine_orm' => [],
                 'services' => [],
             ],
+            'http' => [
+                'client' => null,
+                'message_factory' => null,
+            ],
         ];
 
         $this->assertSame($expected, $this->processConfiguration([[]]));
@@ -96,6 +100,10 @@ class ConfigurationTest extends TestCase
             'sitemap' => [
                 'doctrine_orm' => [],
                 'services' => [],
+            ],
+            'http' => [
+                'client' => null,
+                'message_factory' => null,
             ],
         ];
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because this adds a new implementation without removing the existing one. This is a rework of #161, but targets the psr http-client.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Added
- Added support for `psr/http-client` in `TwitterEmbedTweetBlockService`
```
## Subject

Added support for an abstract http client without removing the existing old guzzle implementation.
