### PR TITLE
Create new Breadcrumb interface

### DIFF
--- a/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
+++ b/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
@@ -18,6 +18,7 @@ use Knp\Menu\ItemInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\MenuBlockService;
+use Sonata\SeoBundle\BreadcrumbInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -26,7 +27,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
-abstract class BaseBreadcrumbMenuBlockService extends MenuBlockService
+abstract class BaseBreadcrumbMenuBlockService extends MenuBlockService implements BreadcrumbInterface
 {
     /**
      * @var string

--- a/src/BreadcrumbInterface.php
+++ b/src/BreadcrumbInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\SeoBundle;
+
+use Sonata\BlockBundle\Block\Service\BlockServiceInterface;
+
+interface BreadcrumbInterface extends BlockServiceInterface
+{
+    /**
+     * @param string $context
+     *
+     * @return bool
+     */
+    public function handleContext($context);
+}

--- a/src/Event/BreadcrumbListener.php
+++ b/src/Event/BreadcrumbListener.php
@@ -16,6 +16,7 @@ namespace Sonata\SeoBundle\Event;
 use Sonata\BlockBundle\Block\BlockServiceInterface;
 use Sonata\BlockBundle\Event\BlockEvent;
 use Sonata\BlockBundle\Model\Block;
+use Sonata\SeoBundle\BreadcrumbInterface;
 
 /**
  * BreadcrumbListener for Block Event.
@@ -32,11 +33,21 @@ class BreadcrumbListener
     /**
      * Add a renderer to the status services list.
      *
-     * @param string $type
+     * @param string              $type
+     * @param BreadcrumbInterface $breadcrumb
+     *
+     * NEXT_MAJOR: Require BreadcrumbInterface instead of BlockServiceInterface
      */
-    public function addBlockService($type, BlockServiceInterface $blockService)
+    public function addBlockService($type, BlockServiceInterface $breadcrumb)
     {
-        $this->blockServices[$type] = $blockService;
+        if (!$breadcrumb instanceof BreadcrumbInterface) {
+            @trigger_error(
+                sprintf('Passing a %s class is deprecated since 2.x, pass a %s instead', BlockServiceInterface::class, BreadcrumbInterface::class),
+                E_USER_DEPRECATED
+            );
+        }
+
+        $this->blockServices[$type] = $breadcrumb;
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

There is no commen interface for breadcrumbs yet. A breadcrumb must implement a `handleContext` method.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this feature is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataSeoBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added new `BreadcrumbInterface`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
