### PR TITLE
Fix wrong phpdoc return type

### DIFF
--- a/src/Seo/SeoPage.php
+++ b/src/Seo/SeoPage.php
@@ -280,7 +280,7 @@ class SeoPage implements SeoPageInterface
     /**
      * @param string $name
      *
-     * @return array
+     * @return bool
      */
     public function hasHeadAttribute($name)
     {
@@ -358,7 +358,7 @@ class SeoPage implements SeoPageInterface
     /**
      * @param string $href
      *
-     * @return $this
+     * @return bool
      */
     public function hasLangAlternate($href)
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a pedantic change..

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

