### PR TITLE
fix_knp_menu_type_error

### DIFF
--- a/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
+++ b/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
@@ -121,9 +121,8 @@ abstract class BaseBreadcrumbMenuBlockService extends MenuBlockService implement
             $menu->setCurrentUri($settings['current_uri']);
         }
 
-        if (method_exists($menu, 'setCurrent')) {
-            $menu->setCurrent($settings['current_uri']);
-        }
+        $menu->setCurrent(true);
+        $menu->setUri($settings['current_uri']);
 
         if ($settings['include_homepage_link']) {
             $menu->addChild('sonata_seo_homepage_breadcrumb', ['uri' => '/']);

--- a/tests/Block/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Block/Breadcrumb/BreadcrumbTest.php
@@ -14,13 +14,26 @@ declare(strict_types=1);
 namespace Sonata\SeoBundle\Tests\Block\Breadcrumb;
 
 use Knp\Menu\FactoryInterface;
+use Knp\Menu\MenuFactory;
 use Knp\Menu\Provider\MenuProviderInterface;
+use Sonata\BlockBundle\Block\BlockContext;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
 use Sonata\SeoBundle\Block\Breadcrumb\BaseBreadcrumbMenuBlockService;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Bundle\TwigBundle\TwigEngine;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Templating\TemplateNameParser;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
 
 class BreadcrumbMenuBlockService_Test extends BaseBreadcrumbMenuBlockService
 {
+    protected function getMenu(BlockContextInterface $blockContext)
+    {
+        return $this->getRootMenu($blockContext);
+    }
 }
 
 /**
@@ -39,5 +52,36 @@ class BreadcrumbTest extends BlockServiceTestCase
         );
 
         $this->assertTrue($blockService->handleContext('context'));
+    }
+
+    public function testGetMenu(): void
+    {
+        $blockService = new BreadcrumbMenuBlockService_Test(
+            'context',
+            'name',
+            new TwigEngine(
+                new Environment(new ArrayLoader([
+                    'breadcrumbs.txt.twig' => 'This is a breadcrumbs with URI {{ menu.uri }}',
+                ])),
+                new TemplateNameParser(),
+                new FileLocator()
+            ),
+            $this->createStub(MenuProviderInterface::class),
+            new MenuFactory()
+        );
+
+        $context = new BlockContext(
+            $this->createStub(BlockInterface::class),
+            [
+                'current_uri' => '/foo/bar',
+                'include_homepage_link' => false,
+                'cache_policy' => 'public',
+                'template' => 'breadcrumbs.txt.twig',
+            ]
+        );
+        self::assertStringContainsString(
+            '/foo/bar',
+            $blockService->execute($context)->getContent()
+        );
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
The Pull Request suggest a fix that correct a parameter type problem. Indeed, a string is given instead of a boolean.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because the fix is BC. The SonataSeoBundle 2.x version needs at least php7.2 which contains parameter types on methods.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #419

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataSeoBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- Fix parameter type when calling knp menu
```
