### PR TITLE
Revert old title

### DIFF
--- a/src/Block/Social/EmailShareButtonBlockService.php
+++ b/src/Block/Social/EmailShareButtonBlockService.php
@@ -81,7 +81,7 @@ final class EmailShareButtonBlockService extends AbstractBlockService implements
 
     public function getMetadata(): MetadataInterface
     {
-        return new Metadata('sonata.seo.block.pinterest.share_button', null, null, 'SonataSeoBundle', [
+        return new Metadata('Share via E-Mail', 'sonata.seo.block.pinterest.share_button', null, 'SonataSeoBundle', [
             'class' => 'fa fa-envelope-o',
         ]);
     }

--- a/src/Block/Social/FacebookLikeBoxBlockService.php
+++ b/src/Block/Social/FacebookLikeBoxBlockService.php
@@ -103,7 +103,7 @@ final class FacebookLikeBoxBlockService extends BaseFacebookSocialPluginsBlockSe
 
     public function getMetadata(): MetadataInterface
     {
-        return new Metadata('sonata.seo.block.facebook.like_box', null, null, 'SonataSeoBundle', [
+        return new Metadata('Facebook - Likebox', 'sonata.seo.block.facebook.like_box', null, 'SonataSeoBundle', [
             'class' => 'fa fa-facebook-official',
         ]);
     }

--- a/src/Block/Social/FacebookLikeButtonBlockService.php
+++ b/src/Block/Social/FacebookLikeButtonBlockService.php
@@ -118,7 +118,7 @@ final class FacebookLikeButtonBlockService extends BaseFacebookSocialPluginsBloc
 
     public function getMetadata(): MetadataInterface
     {
-        return new Metadata('sonata.seo.block.facebook.like_button', null, null, 'SonataSeoBundle', [
+        return new Metadata('Facebook - Like button', 'sonata.seo.block.facebook.like_button', null, 'SonataSeoBundle', [
             'class' => 'fa fa-facebook-official',
         ]);
     }

--- a/src/Block/Social/FacebookSendButtonBlockService.php
+++ b/src/Block/Social/FacebookSendButtonBlockService.php
@@ -82,7 +82,7 @@ final class FacebookSendButtonBlockService extends BaseFacebookSocialPluginsBloc
 
     public function getMetadata(): MetadataInterface
     {
-        return new Metadata('sonata.seo.block.facebook.send_button', null, null, 'SonataSeoBundle', [
+        return new Metadata('Facebook - Send', 'sonata.seo.block.facebook.send_button', null, 'SonataSeoBundle', [
             'class' => 'fa fa-facebook-official',
         ]);
     }

--- a/src/Block/Social/FacebookShareButtonBlockService.php
+++ b/src/Block/Social/FacebookShareButtonBlockService.php
@@ -88,7 +88,7 @@ final class FacebookShareButtonBlockService extends BaseFacebookSocialPluginsBlo
 
     public function getMetadata(): MetadataInterface
     {
-        return new Metadata('sonata.seo.block.facebook.share_button', null, null, 'SonataSeoBundle', [
+        return new Metadata('Facebook - Share', 'sonata.seo.block.facebook.share_button', null, 'SonataSeoBundle', [
             'class' => 'fa fa-facebook-official',
         ]);
     }

--- a/src/Block/Social/PinterestPinButtonBlockService.php
+++ b/src/Block/Social/PinterestPinButtonBlockService.php
@@ -105,7 +105,7 @@ final class PinterestPinButtonBlockService extends AbstractBlockService implemen
 
     public function getMetadata(): MetadataInterface
     {
-        return new Metadata('sonata.seo.block.pinterest.pin_button', null, null, 'SonataSeoBundle', [
+        return new Metadata('Pinterest - Pin', 'sonata.seo.block.pinterest.pin_button', null, 'SonataSeoBundle', [
             'class' => 'fa fa-pinterest-p',
         ]);
     }

--- a/src/Block/Social/TwitterEmbedTweetBlockService.php
+++ b/src/Block/Social/TwitterEmbedTweetBlockService.php
@@ -156,7 +156,7 @@ class TwitterEmbedTweetBlockService extends BaseTwitterButtonBlockService implem
 
     public function getMetadata(): MetadataInterface
     {
-        return new Metadata('sonata.seo.block.twitter.embed', null, null, 'SonataSeoBundle', [
+        return new Metadata('Twitter - Embed', 'sonata.seo.block.twitter.embed', null, 'SonataSeoBundle', [
             'class' => 'fa fa-twitter',
         ]);
     }

--- a/src/Block/Social/TwitterFollowButtonBlockService.php
+++ b/src/Block/Social/TwitterFollowButtonBlockService.php
@@ -87,7 +87,7 @@ final class TwitterFollowButtonBlockService extends BaseTwitterButtonBlockServic
 
     public function getMetadata(): MetadataInterface
     {
-        return new Metadata('sonata.seo.block.twitter.follow_button', null, null, 'SonataSeoBundle', [
+        return new Metadata('Twitter - Fallow', 'sonata.seo.block.twitter.follow_button', null, 'SonataSeoBundle', [
             'class' => 'fa fa-twitter',
         ]);
     }

--- a/src/Block/Social/TwitterHashtagButtonBlockService.php
+++ b/src/Block/Social/TwitterHashtagButtonBlockService.php
@@ -98,7 +98,7 @@ final class TwitterHashtagButtonBlockService extends BaseTwitterButtonBlockServi
 
     public function getMetadata(): MetadataInterface
     {
-        return new Metadata('sonata.seo.block.twitter.hashtag_button', null, null, 'SonataSeoBundle', [
+        return new Metadata('Twitter - Hashtag', 'sonata.seo.block.twitter.hashtag_button', null, 'SonataSeoBundle', [
             'class' => 'fa fa-twitter',
         ]);
     }

--- a/src/Block/Social/TwitterMentionButtonBlockService.php
+++ b/src/Block/Social/TwitterMentionButtonBlockService.php
@@ -92,7 +92,7 @@ final class TwitterMentionButtonBlockService extends BaseTwitterButtonBlockServi
 
     public function getMetadata(): MetadataInterface
     {
-        return new Metadata('sonata.seo.block.twitter.mention_button', null, null, 'SonataSeoBundle', [
+        return new Metadata('Twitter - Mention', 'sonata.seo.block.twitter.mention_button', null, 'SonataSeoBundle', [
             'class' => 'fa fa-twitter',
         ]);
     }

--- a/src/Block/Social/TwitterShareButtonBlockService.php
+++ b/src/Block/Social/TwitterShareButtonBlockService.php
@@ -108,7 +108,7 @@ final class TwitterShareButtonBlockService extends BaseTwitterButtonBlockService
 
     public function getMetadata(): MetadataInterface
     {
-        return new Metadata('sonata.seo.block.twitter.share_button', null, null, 'SonataSeoBundle', [
+        return new Metadata('Twitter - Share', 'sonata.seo.block.twitter.share_button', null, 'SonataSeoBundle', [
             'class' => 'fa fa-twitter',
         ]);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

This PR will restore old metadata titles for blocks:
 
![image](https://user-images.githubusercontent.com/2255674/110339163-21db4f00-8028-11eb-9f70-c1ff772e62a6.png)

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change should be done here.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.

-->

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataSeoBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->
