### PR TITLE
Specify block bundle versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.3 || ^8.0",
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0",
-        "sonata-project/block-bundle": ">=3.11 <4.0",
+        "sonata-project/block-bundle": "^3.11",
         "sonata-project/exporter": "^2.0",
         "symfony/config": "^4.4 || ^5.0",
         "symfony/dependency-injection": "^4.4 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "php": "^7.3 || ^8.0",
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0",
+        "sonata-project/block-bundle": ">=3.11 <4.0",
         "sonata-project/exporter": "^2.0",
         "symfony/config": "^4.4 || ^5.0",
         "symfony/dependency-injection": "^4.4 || ^5.0",
@@ -34,14 +35,12 @@
         "twig/twig": "^2.9 || ^3.0"
     },
     "conflict": {
-        "sonata-project/block-bundle": "<3.11",
         "sonata-project/core-bundle": "<3.20"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^6.0",
         "nyholm/psr7": "^1.2",
         "sonata-project/admin-bundle": "^3.31",
-        "sonata-project/block-bundle": "^3.17",
         "sonata-project/doctrine-extensions": "^1.10.1",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/console": "^4.4 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.3 || ^8.0",
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0",
-        "sonata-project/block-bundle": "^3.11",
+        "sonata-project/block-bundle": "^3.17",
         "sonata-project/exporter": "^2.0",
         "symfony/config": "^4.4 || ^5.0",
         "symfony/dependency-injection": "^4.4 || ^5.0",


### PR DESCRIPTION
Fix to issue #540

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

Fix block bundle requirement

I am targeting this branch, because it is a clarification of an already-existing dependency, rather than a breaking change. (Currently, if a block bundle outside of the range I'm specifying is installed, the SEO bundle malfunctions. So this is a clarification, rather than something that significantly changes existing behavior.)

Closes #540.

## Changelog

Commit one: Changed composer.json. Removed conflict listing and dev dependency, since the block bundle is now listed as a main dependency.
Commit two: Updated composer.json. Bumped block bundle version requirement from ^3.11 to ^3.17 in order to fix a missing test case.