### PR TITLE
Add missing test dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
     },
     "require-dev": {
         "knplabs/knp-menu": "^3.0",
+        "knplabs/knp-menu-bundle": "^3.0",
         "symfony/console": "^4.4 || ^5.3",
         "symfony/filesystem": "^4.4 || ^5.3",
         "symfony/finder": "^4.4 || ^5.3",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Supports #576 

The dependency is required for this: https://github.com/sonata-project/SonataSeoBundle/blob/322d6c782116ece88c4df16e0de4bb68bae743e4/tests/DependencyInjection/SonataSeoExtensionTest.php#L16

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a patch.
