### PR TITLE
Drop support for PHP 7.3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,6 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - '7.3'
                     - '7.4'
                     - '8.0'
                 dependencies: [highest]
@@ -33,7 +32,7 @@ jobs:
                 symfony-require: [""]
                 variant: [normal]
                 include:
-                    - php-version: '7.3'
+                    - php-version: '7.4'
                       dependencies: lowest
                       allowed-to-fail: false
                       variant: normal

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "sonata-project/block-bundle": "^4.0",
         "sonata-project/doctrine-extensions": "^1.10.1",

--- a/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
+++ b/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
@@ -28,10 +28,7 @@ use Twig\Environment;
  */
 abstract class BaseBreadcrumbMenuBlockService extends AbstractBlockService implements BreadcrumbInterface
 {
-    /**
-     * @var FactoryInterface
-     */
-    private $factory;
+    private FactoryInterface $factory;
 
     public function __construct(Environment $twig, FactoryInterface $factory)
     {

--- a/src/Command/SitemapGeneratorCommand.php
+++ b/src/Command/SitemapGeneratorCommand.php
@@ -33,25 +33,16 @@ use Symfony\Component\Routing\RouterInterface;
  */
 final class SitemapGeneratorCommand extends Command
 {
-    /**
-     * @var RouterInterface
-     */
-    private $router;
+    private RouterInterface $router;
 
-    /**
-     * @var SourceManager
-     */
-    private $sitemapManager;
+    private SourceManager $sitemapManager;
 
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
+    private Filesystem $filesystem;
 
     public function __construct(
-        ?RouterInterface $router,
-        ?SourceManager $sitemapManager,
-        ?Filesystem $filesystem
+        RouterInterface $router,
+        SourceManager $sitemapManager,
+        Filesystem $filesystem
     ) {
         $this->router = $router;
         $this->sitemapManager = $sitemapManager;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -22,7 +22,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 final class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sonata_seo');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Event/BreadcrumbListener.php
+++ b/src/Event/BreadcrumbListener.php
@@ -24,10 +24,7 @@ use Sonata\SeoBundle\BreadcrumbInterface;
  */
 final class BreadcrumbListener
 {
-    /**
-     * @var array
-     */
-    private $blockServices = [];
+    private array $blockServices = [];
 
     /**
      * Add a renderer to the status services list.

--- a/src/Seo/SeoAwareTrait.php
+++ b/src/Seo/SeoAwareTrait.php
@@ -16,11 +16,9 @@ namespace Sonata\SeoBundle\Seo;
 trait SeoAwareTrait
 {
     /**
-     * @var SeoPageInterface|null
-     *
      * @required
      */
-    protected $seoPage;
+    protected ?SeoPageInterface $seoPage;
 
     public function setSeoPage(?SeoPageInterface $seoPage = null): void
     {

--- a/src/Seo/SeoPage.php
+++ b/src/Seo/SeoPage.php
@@ -18,50 +18,38 @@ namespace Sonata\SeoBundle\Seo;
  */
 final class SeoPage implements SeoPageInterface
 {
-    /**
-     * @var string
-     */
-    private $title;
+    private string $title;
 
     /**
      * @var array<string, array<string, mixed>>
      */
-    private $metas;
+    private array $metas;
 
     /**
      * @var array<string, string>
      */
-    private $htmlAttributes;
+    private array $htmlAttributes;
 
-    /**
-     * @var string
-     */
-    private $linkCanonical;
+    private string $linkCanonical;
 
-    /**
-     * @var string
-     */
-    private $separator;
+    private string $separator;
 
     /**
      * @var array<string, string>
      */
-    private $headAttributes;
+    private array $headAttributes;
 
     /**
      * @var array<string, string>
      */
-    private $langAlternates;
+    private array $langAlternates;
 
     /**
      * @var array<string, string>
      */
-    private $oembedLinks;
+    private array $oembedLinks;
 
-    /**
-     * @param string $title
-     */
-    public function __construct($title = '')
+    public function __construct(string $title = '')
     {
         $this->title = $title;
         $this->metas = [
@@ -80,31 +68,31 @@ final class SeoPage implements SeoPageInterface
         $this->oembedLinks = [];
     }
 
-    public function setTitle($title)
+    public function setTitle(string $title): self
     {
         $this->title = $title;
 
         return $this;
     }
 
-    public function addTitle($title)
+    public function addTitle(string $title): self
     {
         $this->title = $title.$this->separator.$this->title;
 
         return $this;
     }
 
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->title;
     }
 
-    public function getMetas()
+    public function getMetas(): array
     {
         return $this->metas;
     }
 
-    public function addMeta($type, $name, $value, array $extras = [])
+    public function addMeta(string $type, string $name, string $value, array $extras = []): self
     {
         if (!\is_string($value)) {
             @trigger_error(sprintf(
@@ -123,19 +111,19 @@ final class SeoPage implements SeoPageInterface
         return $this;
     }
 
-    public function hasMeta($type, $name)
+    public function hasMeta(string $type, string $name): bool
     {
         return isset($this->metas[$type][$name]);
     }
 
-    public function removeMeta($type, $name)
+    public function removeMeta(string $type, string $name): self
     {
         unset($this->metas[$type][$name]);
 
         return $this;
     }
 
-    public function setMetas(array $metas)
+    public function setMetas(array $metas): self
     {
         $this->metas = [];
 
@@ -154,76 +142,76 @@ final class SeoPage implements SeoPageInterface
         return $this;
     }
 
-    public function setHtmlAttributes(array $attributes)
+    public function setHtmlAttributes(array $attributes): self
     {
         $this->htmlAttributes = $attributes;
 
         return $this;
     }
 
-    public function addHtmlAttributes($name, $value)
+    public function addHtmlAttributes(string $name, string $value): self
     {
         $this->htmlAttributes[$name] = $value;
 
         return $this;
     }
 
-    public function removeHtmlAttributes($name)
+    public function removeHtmlAttributes(string $name): self
     {
         unset($this->htmlAttributes[$name]);
 
         return $this;
     }
 
-    public function getHtmlAttributes()
+    public function getHtmlAttributes(): array
     {
         return $this->htmlAttributes;
     }
 
-    public function hasHtmlAttribute($name)
+    public function hasHtmlAttribute(string $name): bool
     {
         return isset($this->htmlAttributes[$name]);
     }
 
-    public function setHeadAttributes(array $attributes)
+    public function setHeadAttributes(array $attributes): self
     {
         $this->headAttributes = $attributes;
 
         return $this;
     }
 
-    public function addHeadAttribute($name, $value)
+    public function addHeadAttribute(string $name, string $value): self
     {
         $this->headAttributes[$name] = $value;
 
         return $this;
     }
 
-    public function removeHeadAttribute($name)
+    public function removeHeadAttribute(string $name): self
     {
         unset($this->headAttributes[$name]);
 
         return $this;
     }
 
-    public function getHeadAttributes()
+    public function getHeadAttributes(): array
     {
         return $this->headAttributes;
     }
 
-    public function hasHeadAttribute($name)
+    public function hasHeadAttribute(string $name): bool
     {
         return isset($this->headAttributes[$name]);
     }
 
-    public function setLinkCanonical($link)
+    public function setLinkCanonical(string $link): self
     {
         $this->linkCanonical = $link;
 
         return $this;
     }
 
-    public function getLinkCanonical()
+    public function getLinkCanonical(): string
     {
         return $this->linkCanonical;
     }
@@ -233,58 +221,58 @@ final class SeoPage implements SeoPageInterface
         $this->linkCanonical = '';
     }
 
-    public function setSeparator($separator)
+    public function setSeparator(string $separator): self
     {
         $this->separator = $separator;
 
         return $this;
     }
 
-    public function setLangAlternates(array $langAlternates)
+    public function setLangAlternates(array $langAlternates): self
     {
         $this->langAlternates = $langAlternates;
 
         return $this;
     }
 
-    public function addLangAlternate($href, $hrefLang)
+    public function addLangAlternate(string $href, string $hrefLang): self
     {
         $this->langAlternates[$href] = $hrefLang;
 
         return $this;
     }
 
-    public function removeLangAlternate($href)
+    public function removeLangAlternate(string $href): self
     {
         unset($this->langAlternates[$href]);
 
         return $this;
     }
 
-    public function hasLangAlternate($href)
+    public function hasLangAlternate(string $href): bool
     {
         return isset($this->langAlternates[$href]);
     }
 
-    public function getLangAlternates()
+    public function getLangAlternates(): array
     {
         return $this->langAlternates;
     }
 
-    public function addOEmbedLink($title, $link)
+    public function addOEmbedLink(string $title, string $link): self
     {
         $this->oembedLinks[$title] = $link;
 
         return $this;
     }
 
-    public function getOEmbedLinks()
+    public function getOEmbedLinks(): array
     {
         return $this->oembedLinks;
     }
 
     /**
-     * @param string|array $meta
+     * @param array|string $meta
      */
     private function normalize($meta): array
     {

--- a/src/Seo/SeoPageInterface.php
+++ b/src/Seo/SeoPageInterface.php
@@ -13,205 +13,91 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\Seo;
 
-/**
- * @method SeoPageInterface removeMeta(string $type, string $name)
- * @method SeoPageInterface removeHtmlAttributes(string $name)
- * @method bool             hasHtmlAttribute(string $name)
- * @method SeoPageInterface removeHeadAttribute(string $name)
- * @method bool             hasHeadAttribute(string $name)
- * @method SeoPageInterface removeLangAlternate(string $href)
- * @method bool             hasLangAlternate(string $href)
- */
 interface SeoPageInterface
 {
-    /**
-     * @param string $title
-     *
-     * @return SeoPageInterface
-     */
-    public function setTitle($title);
+    public function setTitle(string $title): self;
+
+    public function addTitle(string $title): self;
+
+    public function getTitle(): string;
 
     /**
-     * @param string $title
-     *
-     * @return SeoPageInterface
-     */
-    public function addTitle($title);
-
-    /**
-     * @return string
-     */
-    public function getTitle();
-
-    /**
-     * @param string               $type
-     * @param string               $name
-     * @param string               $value
      * @param array<string, mixed> $extras
-     *
-     * @return SeoPageInterface
      */
-    public function addMeta($type, $name, $value, array $extras = []);
+    public function addMeta(string $type, string $name, string $value, array $extras = []): self;
 
-    /**
-     * @param string $type
-     * @param string $name
-     *
-     * @return bool
-     */
-    public function hasMeta($type, $name);
+    public function hasMeta(string $type, string $name): bool;
 
     /**
      * @return array<string, array<string, mixed>>
      */
-    public function getMetas();
+    public function getMetas(): array;
 
     /**
      * @param array<string, array<string, mixed>> $metas
-     *
-     * @return SeoPageInterface
      */
-    public function setMetas(array $metas);
+    public function setMetas(array $metas): self;
 
     /**
      * @param array<string, string> $attributes
-     *
-     * @return SeoPageInterface
      */
-    public function setHtmlAttributes(array $attributes);
+    public function setHtmlAttributes(array $attributes): self;
 
-    /**
-     * @param string $name
-     * @param string $value
-     *
-     * @return SeoPageInterface
-     */
-    public function addHtmlAttributes($name, $value);
+    public function addHtmlAttributes(string $name, string $value): self;
 
     /**
      * @return array<string, string>
      */
-    public function getHtmlAttributes();
+    public function getHtmlAttributes(): array;
 
     /**
      * @param array<string, string> $attributes
-     *
-     * @return SeoPageInterface
      */
-    public function setHeadAttributes(array $attributes);
+    public function setHeadAttributes(array $attributes): self;
 
-    /**
-     * @param string $name
-     * @param string $value
-     *
-     * @return SeoPageInterface
-     */
-    public function addHeadAttribute($name, $value);
+    public function addHeadAttribute(string $name, string $value): self;
 
     /**
      * @return array<string, string>
      */
-    public function getHeadAttributes();
+    public function getHeadAttributes(): array;
 
-    /**
-     * @param string $link
-     *
-     * @return SeoPageInterface
-     */
-    public function setLinkCanonical($link);
+    public function setLinkCanonical(string $link): self;
 
-    /**
-     * @return string
-     */
-    public function getLinkCanonical();
+    public function getLinkCanonical(): string;
 
-    /**
-     * @param string $separator
-     *
-     * @return SeoPageInterface
-     */
-    public function setSeparator($separator);
+    public function setSeparator(string $separator): self;
 
     /**
      * @param array<string, string> $langAlternates
-     *
-     * @return SeoPageInterface
      */
-    public function setLangAlternates(array $langAlternates);
+    public function setLangAlternates(array $langAlternates): self;
 
-    /**
-     * @param string $href
-     * @param string $hrefLang
-     *
-     * @return SeoPageInterface
-     */
-    public function addLangAlternate($href, $hrefLang);
+    public function addLangAlternate(string $href, string $hrefLang): self;
 
     /**
      * @return array<string, string>
      */
-    public function getLangAlternates();
+    public function getLangAlternates(): array;
 
-    /**
-     * @param string $title
-     * @param string $link
-     *
-     * @return SeoPageInterface
-     */
-    public function addOEmbedLink($title, $link);
+    public function addOEmbedLink(string $title, string $link): self;
 
     /**
      * @return array<string, string>
      */
-    public function getOEmbedLinks();
+    public function getOEmbedLinks(): array;
 
-    /**
-     * @param string $type
-     * @param string $name
-     *
-     * @return $this
-     */
-    public function removeMeta($type, $name);
+    public function removeMeta(string $type, string $name): self;
 
-    /**
-     * @param string $name
-     *
-     * @return $this
-     */
-    public function removeHtmlAttributes($name);
+    public function removeHtmlAttributes(string $name): self;
 
-    /**
-     * @param string $name
-     *
-     * @return bool
-     */
-    public function hasHtmlAttribute($name);
+    public function hasHtmlAttribute(string $name): bool;
 
-    /**
-     * @param string $name
-     *
-     * @return $this
-     */
-    public function removeHeadAttribute($name);
+    public function removeHeadAttribute(string $name): self;
 
-    /**
-     * @param string $name
-     *
-     * @return bool
-     */
-    public function hasHeadAttribute($name);
+    public function hasHeadAttribute(string $name): bool;
 
-    /**
-     * @param string $href
-     *
-     * @return $this
-     */
-    public function removeLangAlternate($href);
+    public function removeLangAlternate(string $href): self;
 
-    /**
-     * @param string $href
-     *
-     * @return bool
-     */
-    public function hasLangAlternate($href);
+    public function hasLangAlternate(string $href): bool;
 }

--- a/src/Sitemap/SourceManager.php
+++ b/src/Sitemap/SourceManager.php
@@ -21,10 +21,7 @@ use Sonata\Exporter\Source\SourceIteratorInterface;
  */
 final class SourceManager implements SourceIteratorInterface
 {
-    /**
-     * @var \ArrayIterator
-     */
-    private $sources;
+    private \ArrayIterator $sources;
 
     public function __construct()
     {
@@ -33,10 +30,8 @@ final class SourceManager implements SourceIteratorInterface
 
     /**
      * Adding source with his group.
-     *
-     * @param string $group
      */
-    public function addSource($group, SourceIteratorInterface $source, array $types = []): void
+    public function addSource(string $group, SourceIteratorInterface $source, array $types = []): void
     {
         if (!isset($this->sources[$group])) {
             $this->sources[$group] = new \stdClass();
@@ -67,7 +62,7 @@ final class SourceManager implements SourceIteratorInterface
         return $this->sources->key();
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return $this->sources->valid();
     }

--- a/src/Twig/Extension/SeoExtension.php
+++ b/src/Twig/Extension/SeoExtension.php
@@ -19,15 +19,9 @@ use Twig\TwigFunction;
 
 final class SeoExtension extends AbstractExtension
 {
-    /**
-     * @var SeoPageInterface
-     */
-    private $page;
+    private SeoPageInterface $page;
 
-    /**
-     * @var string
-     */
-    private $encoding;
+    private string $encoding;
 
     public function __construct(SeoPageInterface $page, string $encoding)
     {
@@ -35,7 +29,7 @@ final class SeoExtension extends AbstractExtension
         $this->encoding = $encoding;
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('sonata_seo_title', [$this, 'getTitle'], ['is_safe' => ['html']]),

--- a/tests/Block/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Block/Breadcrumb/BreadcrumbTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\SeoBundle\Tests\Block\Breadcrumb;
 
 use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
 use Knp\Menu\MenuFactory;
 use Sonata\BlockBundle\Block\BlockContext;
 use Sonata\BlockBundle\Block\BlockContextInterface;
@@ -30,7 +31,7 @@ final class BreadcrumbMenuBlockService_Test extends BaseBreadcrumbMenuBlockServi
         return 'test';
     }
 
-    protected function getMenu(BlockContextInterface $blockContext)
+    protected function getMenu(BlockContextInterface $blockContext): ItemInterface
     {
         return $this->getRootMenu($blockContext);
     }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -86,7 +86,7 @@ final class ConfigurationTest extends TestCase
         static::assertSame('website', $config['page']['metas']['property']['og:type']);
     }
 
-    private function getDefaultConfiguration()
+    private function getDefaultConfiguration(): array
     {
         return [
             'page' => [
@@ -108,7 +108,7 @@ final class ConfigurationTest extends TestCase
         ];
     }
 
-    private function processConfiguration(array $configs)
+    private function processConfiguration(array $configs): array
     {
         $configuration = new Configuration();
         $processor = new Processor();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Drop support for PHP 7.3, because active support will end in a few days. This allows us to add type hints everywhere.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a major change.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataSeoBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Added type hints to every property and method.

### Removed
- Dropped support for PHP 7.3

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
