### PR TITLE
Improve title handling

### DIFF
--- a/docs/reference/twig_helpers.rst
+++ b/docs/reference/twig_helpers.rst
@@ -16,6 +16,19 @@ This will render the page title as follows:
 
     <title>My custom title</title>
 
+Render the page title text
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: twig
+
+    {{ sonata_seo_title_text() }}
+
+This will render the page title as follows:
+
+.. code-block:: html
+
+    My custom title
+
 Render page metadata
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/reference/usage.rst
+++ b/docs/reference/usage.rst
@@ -39,7 +39,7 @@ You could also prepend the page title, so that the global title is used as a suf
     $seoPage = $this->container->get('sonata.seo.page');
 
     $seoPage
-        ->addTitle($post->getTitle());
+        ->addTitlePrefix($post->getTitle());
 
 .. note::
 

--- a/src/Seo/SeoPage.php
+++ b/src/Seo/SeoPage.php
@@ -61,6 +61,11 @@ class SeoPage implements SeoPageInterface
     protected $oembedLinks;
 
     /**
+     * @var string
+     */
+    private $originalTitle;
+
+    /**
      * @param string $title
      */
     public function __construct($title = '')
@@ -85,13 +90,34 @@ class SeoPage implements SeoPageInterface
     public function setTitle($title)
     {
         $this->title = $title;
+        $this->originalTitle = $title;
 
         return $this;
     }
 
     public function addTitle($title)
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since 2.x, to be removed in 3.0. '.
+            'Use '.__NAMESPACE__.'::addTitlePrefix() or '.__NAMESPACE__.'::addTitleSuffix .instead.',
+            \E_USER_DEPRECATED
+        );
+
         $this->title = $title.$this->separator.$this->title;
+
+        return $this;
+    }
+
+    public function addTitlePrefix(string $prefix): self
+    {
+        $this->title = $prefix.$this->separator.$this->title;
+
+        return $this;
+    }
+
+    public function addTitleSuffix(string $suffix): self
+    {
+        $this->title .= $this->separator.$suffix;
 
         return $this;
     }
@@ -99,6 +125,11 @@ class SeoPage implements SeoPageInterface
     public function getTitle()
     {
         return $this->title;
+    }
+
+    public function getOriginalTitle(): string
+    {
+        return $this->originalTitle;
     }
 
     public function getMetas()

--- a/src/Seo/SeoPageInterface.php
+++ b/src/Seo/SeoPageInterface.php
@@ -21,6 +21,9 @@ namespace Sonata\SeoBundle\Seo;
  * @method bool             hasHeadAttribute(string $name)
  * @method SeoPageInterface removeLangAlternate(string $href)
  * @method bool             hasLangAlternate(string $href)
+ * @method SeoPageInterface addTitlePrefix(string $prefix)
+ * @method SeoPageInterface addTitleSuffix(string $suffix)
+ * @method string           getOriginalTitle)
  */
 interface SeoPageInterface
 {
@@ -32,6 +35,8 @@ interface SeoPageInterface
     public function setTitle($title);
 
     /**
+     * @deprecated since sonata-project/seo-bundle 2.x, to be removed in 3.0. addTitlePrefix or addTitleSuffix instead.
+     *
      * @param string $title
      *
      * @return SeoPageInterface

--- a/src/Twig/Extension/SeoExtension.php
+++ b/src/Twig/Extension/SeoExtension.php
@@ -45,6 +45,7 @@ class SeoExtension extends AbstractExtension
     {
         return [
             new TwigFunction('sonata_seo_title', [$this, 'getTitle'], ['is_safe' => ['html']]),
+            new TwigFunction('sonata_seo_title_text', [$this, 'getTitleText'], ['is_safe' => ['html']]),
             new TwigFunction('sonata_seo_metadatas', [$this, 'getMetadatas'], ['is_safe' => ['html']]),
             new TwigFunction('sonata_seo_html_attributes', [$this, 'getHtmlAttributes'], ['is_safe' => ['html']]),
             new TwigFunction('sonata_seo_head_attributes', [$this, 'getHeadAttributes'], ['is_safe' => ['html']]),
@@ -81,6 +82,11 @@ class SeoExtension extends AbstractExtension
     public function getTitle()
     {
         return sprintf('<title>%s</title>', strip_tags($this->page->getTitle()));
+    }
+
+    public function getTitleText(): string
+    {
+        return $this->page->getOriginalTitle();
     }
 
     /**

--- a/tests/Seo/SeoPageTest.php
+++ b/tests/Seo/SeoPageTest.php
@@ -109,6 +109,9 @@ final class SeoPageTest extends TestCase
         static::assertSame('My title', $page->getTitle());
     }
 
+    /**
+     * @group legacy
+     */
     public function testAddTitle()
     {
         $page = new SeoPage();
@@ -117,6 +120,28 @@ final class SeoPageTest extends TestCase
         $page->addTitle('Additional title');
 
         static::assertSame('Additional title - My title', $page->getTitle());
+    }
+
+    public function addTitlePrefix()
+    {
+        $page = new SeoPage();
+        $page->setTitle('My title');
+        $page->setSeparator(' - ');
+        $page->addTitlePrefix('Additional title');
+
+        static::assertSame('Additional title - My title', $page->getTitle());
+        static::assertSame('My title', $page->getOriginalTitle());
+    }
+
+    public function addTitleSuffix()
+    {
+        $page = new SeoPage();
+        $page->setTitle('My title');
+        $page->setSeparator(' - ');
+        $page->addTitleSuffix('Additional title');
+
+        static::assertSame('My title - Additional title', $page->getTitle());
+        static::assertSame('My title', $page->getOriginalTitle());
     }
 
     public function testLinkCanonical()

--- a/tests/Twig/Extension/SeoExtensionTest.php
+++ b/tests/Twig/Extension/SeoExtensionTest.php
@@ -55,6 +55,16 @@ final class SeoExtensionTest extends TestCase
         static::assertSame('<title>foo bar</title>', $extension->getTitle());
     }
 
+    public function getTitleText(): void
+    {
+        $page = $this->createMock(SeoPageInterface::class);
+        $page->expects(static::once())->method('getTitle')->willReturn('<b>foo bar</b>');
+
+        $extension = new SeoExtension($page, 'UTF-8');
+
+        static::assertSame('foo bar', $extension->getTitleText());
+    }
+
     public function testEncoding()
     {
         $page = $this->createMock(SeoPageInterface::class);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Remove inconsistencies when setting the page title.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this feature is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataSeoBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `SeoPageInterface::addTitlePrefix`
- Added `SeoPageInterface::addTitleSuffix`
- Added `SeoPageInterface::getOriginalTitle`
- Added `sonata_seo_title_text` twig function

### Deprecated
- Deprecated `SeoPageInterface::addTitle`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
