### PR TITLE
Add `sonata_seo_breadcrumb` to render current breadcrumb

### DIFF
--- a/docs/reference/breadcrumb.rst
+++ b/docs/reference/breadcrumb.rst
@@ -53,3 +53,10 @@ And to render the breadcrumb, just use this Twig helper :
         'context': 'my_custom_context',
         'current_uri': app.request.requestUri
     }) }}
+
+
+You can also use the shortcut to render the current breadcrumb :
+
+.. code-block:: twig
+
+    {{ sonata_seo_breadcrumb() }}

--- a/docs/reference/usage.rst
+++ b/docs/reference/usage.rst
@@ -32,6 +32,9 @@ However, it is possible to alter these values at runtime::
             'permalink' => $this->getBlog()->getPermalinkGenerator()->generate($post, true)
         ], true))
         ->addMeta('property', 'og:description', $post->getAbstract())
+        ->setBreadcrumb('news_post', [
+            'post' => $post,
+        ])
     ;
 
 You could also prepend the page title, so that the global title is used as a suffix::

--- a/src/Resources/views/breadcrumb.html.twig
+++ b/src/Resources/views/breadcrumb.html.twig
@@ -1,0 +1,5 @@
+{% if options|length %}
+    {{ sonata_block_render_event('breadcrumb', options|merge({
+        'current_uri': currentUri|default(app.request.requestUri)
+    })) }}
+{% endif %}

--- a/src/Seo/SeoPage.php
+++ b/src/Seo/SeoPage.php
@@ -66,6 +66,11 @@ class SeoPage implements SeoPageInterface
     private $originalTitle;
 
     /**
+     * @var array<string, mixed>
+     */
+    private $breadcrumb;
+
+    /**
      * @param string $title
      */
     public function __construct($title = '')
@@ -314,6 +319,21 @@ class SeoPage implements SeoPageInterface
     public function getOEmbedLinks()
     {
         return $this->oembedLinks;
+    }
+
+    public function setBreadcrumb(string $context, array $options = []): self
+    {
+        $this->breadcrumb = array_merge_recursive([
+            'menu_template' => '@SonataSeo/Block/breadcrumb.html.twig',
+            'context' => $context,
+        ], $options);
+
+        return $this;
+    }
+
+    public function getBreadcrumbOptions(): array
+    {
+        return $this->breadcrumb;
     }
 
     /**

--- a/src/Seo/SeoPageInterface.php
+++ b/src/Seo/SeoPageInterface.php
@@ -24,6 +24,8 @@ namespace Sonata\SeoBundle\Seo;
  * @method SeoPageInterface addTitlePrefix(string $prefix)
  * @method SeoPageInterface addTitleSuffix(string $suffix)
  * @method string           getOriginalTitle)
+ * @method string           setBreadcrumb(string $context, array $options)
+ * @method array            getBreadcrumbOptions()
  */
 interface SeoPageInterface
 {

--- a/src/Twig/Extension/SeoExtension.php
+++ b/src/Twig/Extension/SeoExtension.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\SeoBundle\Twig\Extension;
 
 use Sonata\SeoBundle\Seo\SeoPageInterface;
+use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -52,6 +53,10 @@ class SeoExtension extends AbstractExtension
             new TwigFunction('sonata_seo_link_canonical', [$this, 'getLinkCanonical'], ['is_safe' => ['html']]),
             new TwigFunction('sonata_seo_lang_alternates', [$this, 'getLangAlternates'], ['is_safe' => ['html']]),
             new TwigFunction('sonata_seo_oembed_links', [$this, 'getOembedLinks'], ['is_safe' => ['html']]),
+            new TwigFunction('sonata_seo_breadcrumb', [$this, 'renderBreadcrumb'], [
+                'needs_environment' => true,
+                'is_safe' => ['html'],
+            ]),
         ];
     }
 
@@ -261,6 +266,14 @@ class SeoExtension extends AbstractExtension
         }
 
         return $html;
+    }
+
+    public function renderBreadcrumb(Environment $environment, ?string $currentUri = null): string
+    {
+        return $environment->render('@SonataSeo/breadcrumb.html.twig', [
+            'currentUri' => $currentUri,
+            'options' => $this->page->getBreadcrumbOptions(),
+        ]);
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Add new extension points to render the current breadcrumb using `sonata_seo_breadcrumb`.

The active breadcrumb can be set inside

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this feature is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataSeoBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `SeoPageInterface::setBreadcrumb`
- Added `SeoPageInterface::getBreadcrumbOptions`
- Added `sonata_seo_breadcrumb` twig extension to render current breadcrumb
```
