### PR TITLE
Add priority for breadcrumb blocks

### DIFF
--- a/docs/reference/breadcrumb.rst
+++ b/docs/reference/breadcrumb.rst
@@ -45,6 +45,22 @@ You can extend ``Sonata\SeoBundle\Block\Breadcrumb\BaseBreadcrumbMenuBlockServic
         <tag name="sonata.breadcrumb"/>
     </service>
 
+You can also override the breadcrumb order by defining a ``priority``:
+
+.. code-block:: xml
+
+    <!-- config/services.xml -->
+
+    <service id="app.bundle.block.breadcrumb" class="App\Block\MyCustomBreadcrumbBlockService">
+        <argument>my_custom_context</argument>
+        <argument>acme.bundle.block.breadcrumb</argument>
+        <argument type="service" id="templating"/>
+        <argument type="service" id="knp_menu.menu_provider"/>
+        <argument type="service" id="knp_menu.factory"/>
+        <tag name="sonata.block"/>
+        <tag name="sonata.breadcrumb" priority="-127"/>
+    </service>
+
 And to render the breadcrumb, just use this Twig helper :
 
 .. code-block:: twig

--- a/src/DependencyInjection/Compiler/BreadcrumbBlockServicesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/BreadcrumbBlockServicesCompilerPass.php
@@ -26,8 +26,18 @@ class BreadcrumbBlockServicesCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
+        $queue = new \SplPriorityQueue();
+
+        $order = \PHP_INT_MAX;
         foreach ($container->findTaggedServiceIds('sonata.breadcrumb') as $id => $attributes) {
-            $container->getDefinition('sonata.seo.event.breadcrumb')->addMethodCall('addBlockService', [$id, new Reference($id)]);
+            $priority = $attributes[0]['priority'] ?? 0;
+
+            $queue->insert(new Reference($id), [$priority, --$order]);
+        }
+
+        $definition = $container->getDefinition('sonata.seo.event.breadcrumb');
+        foreach ($queue as $serviceId) {
+            $definition->addMethodCall('addBlockService', [$serviceId->__toString(), $serviceId]);
         }
     }
 }

--- a/tests/DependencyInjection/Compiler/BreadcrumbBlockServicesCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/BreadcrumbBlockServicesCompilerPassTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\SeoBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\SeoBundle\DependencyInjection\Compiler\BreadcrumbBlockServicesCompilerPass;
+use Sonata\SeoBundle\Event\BreadcrumbListener;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class BreadcrumbBlockServicesCompilerPassTest extends TestCase
+{
+    /**
+     * @var ContainerBuilder
+     */
+    private $containerBuilder;
+
+    /**
+     * @var Definition
+     */
+    private $listener;
+
+    /**
+     * @var BreadcrumbBlockServicesCompilerPass
+     */
+    private $compilerPass;
+
+    protected function setUp(): void
+    {
+        $this->containerBuilder = new ContainerBuilder();
+
+        $this->listener = $this->containerBuilder->register('sonata.seo.event.breadcrumb', BreadcrumbListener::class);
+
+        $this->compilerPass = new BreadcrumbBlockServicesCompilerPass();
+    }
+
+    public function testProcess(): void
+    {
+        $this->containerBuilder->register('acme.service', );
+        $this->containerBuilder->register('acme.breadcrumb')
+            ->addTag('sonata.breadcrumb');
+
+        $this->process();
+
+        $this->assertServiceOrder([
+            'acme.breadcrumb',
+        ]);
+    }
+
+    public function testProcessWithStandardPriority(): void
+    {
+        $this->containerBuilder->register('acme.breadcrumbA')
+            ->addTag('sonata.breadcrumb');
+        $this->containerBuilder->register('acme.breadcrumbB')
+            ->addTag('sonata.breadcrumb');
+        $this->containerBuilder->register('acme.breadcrumbC')
+            ->addTag('sonata.breadcrumb');
+        $this->containerBuilder->register('acme.breadcrumbD')
+            ->addTag('sonata.breadcrumb');
+
+        $this->process();
+
+        $this->assertServiceOrder([
+            'acme.breadcrumbA',
+            'acme.breadcrumbB',
+            'acme.breadcrumbC',
+            'acme.breadcrumbD',
+        ]);
+    }
+
+    public function testProcessWithCustomPriority(): void
+    {
+        $this->containerBuilder->register('acme.breadcrumbA')
+            ->addTag('sonata.breadcrumb', ['priority' => -128]);
+        $this->containerBuilder->register('acme.breadcrumbB')
+            ->addTag('sonata.breadcrumb', ['priority' => 0]);
+        $this->containerBuilder->register('acme.breadcrumbC')
+            ->addTag('sonata.breadcrumb', ['priority' => 128]);
+        $this->containerBuilder->register('acme.breadcrumbD')
+            ->addTag('sonata.breadcrumb', ['priority' => -64]);
+
+        $this->process();
+
+        $this->assertServiceOrder([
+            'acme.breadcrumbC',
+            'acme.breadcrumbB',
+            'acme.breadcrumbD',
+            'acme.breadcrumbA',
+        ]);
+    }
+
+    private function getCalledServices(): array
+    {
+        $methodCalls = $this->listener->getMethodCalls();
+
+        return array_map(static function ($call) {
+            return $call[1][0];
+        }, $methodCalls);
+    }
+
+    private function process(): void
+    {
+        $this->compilerPass->process($this->containerBuilder);
+    }
+
+    private function assertServiceOrder(array $services): void
+    {
+        static::assertSame($services, $this->getCalledServices());
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this feature is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #194

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataSeoBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `priority` to `sonata.breadcrumb` tag
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
