### PR TITLE
Allow setting global page prefix and suffix

### DIFF
--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -29,7 +29,9 @@ file.
     sonata_seo:
         encoding:         UTF-8
         page:
-            title:            Project name
+            title:           'Project name'
+            # title_prefix:  'Prefix |'
+            # title_suffix:  '| Suffix'
             default:          sonata.seo.page.default
             metas:
                 name:

--- a/src/DependencyInjection/Compiler/ServiceCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ServiceCompilerPass.php
@@ -29,6 +29,13 @@ final class ServiceCompilerPass implements CompilerPassInterface
         $definition = $container->findDefinition($config['default']);
 
         $definition->addMethodCall('setTitle', [$config['title']]);
+        if (null !== $config['title_prefix']) {
+            $definition->addMethodCall('addTitlePrefix', [$config['title_prefix']]);
+        }
+        if (null !== $config['title_suffix']) {
+            $definition->addMethodCall('addTitleSuffix', [$config['title_suffix']]);
+        }
+
         $definition->addMethodCall('setMetas', [$config['metas']]);
         $definition->addMethodCall('setHtmlAttributes', [$config['head']]);
         $definition->addMethodCall('setSeparator', [$config['separator']]);

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -53,6 +53,8 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('separator')->defaultValue(' - ')->end()
                         // NEXT_MAJOR: Make this field required
                         ->scalarNode('title')->defaultValue('Project name')->end()
+                        ->scalarNode('title_prefix')->defaultNull()->end()
+                        ->scalarNode('title_suffix')->defaultNull()->end()
                     ->end()
                 ->end()
                 ->arrayNode('sitemap')

--- a/tests/DependencyInjection/Compiler/ServiceCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ServiceCompilerPassTest.php
@@ -49,4 +49,30 @@ class ServiceCompilerPassTest extends TestCase
 
         static::assertInstanceOf(SeoPageInterface::class, $container->get(SeoPageInterface::class));
     }
+
+    public function testGlobalTitle(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.bundles', []);
+        $container->register('sonata.seo.custom.page', SeoPage::class);
+
+        $config = [
+            'page' => [
+                'default' => 'sonata.seo.custom.page',
+                'title' => 'Project name',
+                'title_prefix' => 'Prefix',
+                'title_suffix' => 'Suffix',
+            ],
+        ];
+
+        $extension = new SonataSeoExtension();
+        $extension->load([$config], $container);
+
+        (new ServiceCompilerPass())->process($container);
+
+        $page = $container->get('sonata.seo.custom.page');
+
+        static::assertSame('Project name', $page->getOriginalTitle());
+        static::assertSame('Prefix Project name Suffix', $page->getTitle());
+    }
 }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -30,6 +30,8 @@ final class ConfigurationTest extends TestCase
                 'metas' => [],
                 'separator' => ' - ',
                 'title' => 'Project name',
+                'title_prefix' => null,
+                'title_suffix' => null,
             ],
             'sitemap' => [
                 'doctrine_orm' => [],
@@ -95,6 +97,8 @@ final class ConfigurationTest extends TestCase
                 'default' => 'sonata.seo.page.default',
                 'separator' => ' - ',
                 'title' => 'Project name',
+                'title_prefix' => null,
+                'title_suffix' => null,
             ],
             'encoding' => 'UTF-8',
             'sitemap' => [


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this feature is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #157

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataSeoBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Allow setting global page prefix and suffix 
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
