### PR TITLE
Fix null error in SeoPage

### DIFF
--- a/src/Seo/SeoPage.php
+++ b/src/Seo/SeoPage.php
@@ -84,6 +84,7 @@ class SeoPage implements SeoPageInterface
             'property' => [],
         ];
 
+        // NEXT_MAJOR: Use property initialization
         $this->htmlAttributes = [];
         $this->headAttributes = [];
         $this->linkCanonical = '';

--- a/src/Seo/SeoPage.php
+++ b/src/Seo/SeoPage.php
@@ -68,7 +68,7 @@ class SeoPage implements SeoPageInterface
     /**
      * @var array<string, mixed>
      */
-    private $breadcrumb;
+    private $breadcrumb = [];
 
     /**
      * @param string $title


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

There is a null error:

```
Return value of Sonata\SeoBundle\Seo\SeoPage::getBreadcrumbOptions() must be of the type array, null returned
```
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a patch for an untagged release.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes #588

