### PR TITLE
Allow array values for meta tags

### DIFF
--- a/src/Seo/SeoPage.php
+++ b/src/Seo/SeoPage.php
@@ -21,6 +21,12 @@ namespace Sonata\SeoBundle\Seo;
 class SeoPage implements SeoPageInterface
 {
     /**
+     * @var array<string>
+     */
+    private const ALLOW_MULTIPLE_TAGS = [
+        'og:image',
+    ];
+    /**
      * @var string
      */
     protected $title;
@@ -157,7 +163,20 @@ class SeoPage implements SeoPageInterface
             $this->metas[$type] = [];
         }
 
-        $this->metas[$type][$name] = [$value, $extras];
+        $arrayValue = [$value, $extras];
+
+        if (\in_array($name, self::ALLOW_MULTIPLE_TAGS, true)) {
+            if (isset($this->metas[$type][$name])) {
+                [$oldValue, $oldExtras] = $this->metas[$type][$name];
+                if (!\is_array($oldValue)) {
+                    $oldValue = [$oldValue];
+                    $oldExtras = [$oldExtras];
+                }
+                $arrayValue = [array_merge($oldValue, [$value]), array_merge($oldExtras, [$extras])];
+            }
+        }
+
+        $this->metas[$type][$name] = $arrayValue;
 
         return $this;
     }

--- a/src/Seo/SeoPage.php
+++ b/src/Seo/SeoPage.php
@@ -21,7 +21,7 @@ namespace Sonata\SeoBundle\Seo;
 class SeoPage implements SeoPageInterface
 {
     /**
-     * @var array<string>
+     * @var string[]
      */
     private const ALLOW_MULTIPLE_TAGS = [
         'og:image',

--- a/src/Twig/Extension/SeoExtension.php
+++ b/src/Twig/Extension/SeoExtension.php
@@ -121,18 +121,27 @@ class SeoExtension extends AbstractExtension
                 [$content, $extras] = $meta;
 
                 if (!empty($content)) {
-                    $html .= sprintf(
-                        "<meta %s=\"%s\" content=\"%s\" />\n",
-                        $type,
-                        $this->normalize($name),
-                        $this->normalize($content)
-                    );
+                    if (\is_array($content)) {
+                        foreach ($content as $contentKey => $contentItem) {
+                            $html .= $this->generateMetaTag($type, $name, $contentItem);
+                            if (isset($extras[$contentKey]) && \is_array($extras[$contentKey])) {
+                                foreach ($extras[$contentKey] as $extraKey => $extra) {
+                                    if (':' === substr($extraKey, 0, 1)) {
+                                        $html .= $this->generateMetaTag($type, $name.$extraKey, $extra);
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        $html .= $this->generateMetaTag($type, $name, $content);
+                        foreach ($extras as $extraKey => $extra) {
+                            if (':' === substr($extraKey, 0, 1)) {
+                                $html .= $this->generateMetaTag($type, $name.$extraKey, $extra);
+                            }
+                        }
+                    }
                 } else {
-                    $html .= sprintf(
-                        "<meta %s=\"%s\" />\n",
-                        $type,
-                        $this->normalize($name)
-                    );
+                    $html .= $this->generateMetaTag($type, $name);
                 }
             }
         }
@@ -274,6 +283,27 @@ class SeoExtension extends AbstractExtension
             'currentUri' => $currentUri,
             'options' => $this->page->getBreadcrumbOptions(),
         ]);
+    }
+
+    /**
+     * @return string
+     */
+    private function generateMetaTag($type, $name, $content = null)
+    {
+        if (null === $content) {
+            return sprintf(
+                "<meta %s=\"%s\" />\n",
+                $type,
+                $this->normalize($name)
+            );
+        }
+
+        return sprintf(
+            "<meta %s=\"%s\" content=\"%s\" />\n",
+            $type,
+            $this->normalize($name),
+            $this->normalize($content)
+        );
     }
 
     /**

--- a/tests/Seo/SeoPageTest.php
+++ b/tests/Seo/SeoPageTest.php
@@ -34,6 +34,29 @@ final class SeoPageTest extends TestCase
         static::assertSame($expected, $page->getMetas());
     }
 
+    public function testAddArrayMeta()
+    {
+        $page = new SeoPage();
+
+        //Allow multiple tags
+        $page->addMeta('property', 'og:image', 'http://example1.com/');
+        $page->addMeta('property', 'og:image', 'http://example2.com/');
+
+        //Override tag
+        $page->addMeta('property', 'foo', 'foo', ['foo' => 'foo']);
+        $page->addMeta('property', 'foo', 'bar', ['foo' => 'bar']);
+
+        $expected = [
+            'http-equiv' => [],
+            'name' => [],
+            'schema' => [],
+            'charset' => [],
+            'property' => ['og:image' => [['http://example1.com/', 'http://example2.com/'], [[], []]], 'foo' => ['bar', ['foo' => 'bar']]],
+        ];
+
+        static::assertSame($expected, $page->getMetas());
+    }
+
     public function testOverrideMetas()
     {
         $page = new SeoPage();

--- a/tests/Twig/Extension/SeoExtensionTest.php
+++ b/tests/Twig/Extension/SeoExtensionTest.php
@@ -96,7 +96,8 @@ final class SeoExtensionTest extends TestCase
             'schema' => [],
             'charset' => ['UTF-8' => ['', []]],
             'property' => [
-                'og:image:width' => [848, []],
+                'og:image' => ['image1', [':width' => 848]],
+                'og:image:height' => [646, []],
                 'og:type' => [new MetaTest(), []],
             ],
         ]);
@@ -104,7 +105,28 @@ final class SeoExtensionTest extends TestCase
         $extension = new SeoExtension($page, 'UTF-8');
 
         static::assertSame(
-            "<meta name=\"foo\" content=\"bar &quot;'&quot;\" />\n<meta charset=\"UTF-8\" />\n<meta property=\"og:image:width\" content=\"848\" />\n<meta property=\"og:type\" content=\"article\" />\n",
+            "<meta name=\"foo\" content=\"bar &quot;'&quot;\" />\n<meta charset=\"UTF-8\" />\n<meta property=\"og:image\" content=\"image1\" />\n<meta property=\"og:image:width\" content=\"848\" />\n<meta property=\"og:image:height\" content=\"646\" />\n<meta property=\"og:type\" content=\"article\" />\n",
+            $extension->getMetadatas()
+        );
+    }
+
+    public function testArrayMetadatas()
+    {
+        $page = $this->createMock(SeoPageInterface::class);
+        $page->expects(static::once())->method('getMetas')->willReturn([
+            'http-equiv' => [],
+            'name' => [],
+            'schema' => [],
+            'charset' => [],
+            'property' => [
+                'og:image' => [['image1', 'image2'], [['foo' => 'bar', ':width' => '640'], [':width' => '640', ':height' => '480']]],
+            ],
+        ]);
+
+        $extension = new SeoExtension($page, 'UTF-8');
+
+        static::assertSame(
+            "<meta property=\"og:image\" content=\"image1\" />\n<meta property=\"og:image:width\" content=\"640\" />\n<meta property=\"og:image\" content=\"image2\" />\n<meta property=\"og:image:width\" content=\"640\" />\n<meta property=\"og:image:height\" content=\"480\" />\n",
             $extension->getMetadatas()
         );
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

1. Updating **_addMeta()_** function to allow multiple values for specific meta tags: `og:image`

```
$page->addMeta('property', 'og:image', 'http://example.com/image1.jpg');
$page->addMeta('property', 'og:image', 'http://example.com/image2.jpg');
```
Renders as:
```
<meta property="og:image" content="http://example.com/image1.jpg">
<meta property="og:image" content="http://example.com/image2.jpg">
```

2. Utilize the **_$extra_** parameter to define structured properties when their key starts with `:`

```
$page->addMeta('property', 'og:image', 'http://example1.com/image1.jpg', [":width" => 640, ":height" => 480]);
```
Renders as:
```
<meta property="og:image" content="http://example.com/image1.jpg">
<meta property="og:image:width" content="640">
<meta property="og:image:height" content="480">
```
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it's a missing feature and it should be available in 2.x too.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #554

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataSeoBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Extra parameters starting with a colon symbol (`:`) are now rendered as structured properties

### Changed
- Allow calling `SeoPage::addMeta()` with `og:image` multiple times
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
