### PR TITLE
Move BreadcrumbInterface

### DIFF
--- a/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
+++ b/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
@@ -18,7 +18,6 @@ use Knp\Menu\ItemInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\MenuBlockService;
-use Sonata\SeoBundle\BreadcrumbInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -27,7 +26,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
-abstract class BaseBreadcrumbMenuBlockService extends MenuBlockService implements BreadcrumbInterface
+abstract class BaseBreadcrumbMenuBlockService extends MenuBlockService implements BreadcrumbBlockService
 {
     /**
      * @var string

--- a/src/Block/Breadcrumb/BreadcrumbBlockService.php
+++ b/src/Block/Breadcrumb/BreadcrumbBlockService.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\SeoBundle\Block\Breadcrumb;
+
+use Sonata\SeoBundle\BreadcrumbInterface;
+
+interface BreadcrumbBlockService extends BreadcrumbInterface
+{
+}

--- a/src/BreadcrumbInterface.php
+++ b/src/BreadcrumbInterface.php
@@ -15,6 +15,9 @@ namespace Sonata\SeoBundle;
 
 use Sonata\BlockBundle\Block\Service\BlockServiceInterface;
 
+/**
+ * @deprecated since sonata-project/seo-bundle 2.x, to be removed in 3.0. Use Sonata\SeoBundle\Block\Breadcrumb\Breadcrumb instead.
+ */
 interface BreadcrumbInterface extends BlockServiceInterface
 {
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataSeoBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add `Sonata\SeoBundle\Block\Breadcrumb\BreadcrumbBlockService`

### Deprecated
- Deprecate `Sonata\SeoBundle\BreadcrumbInterface`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
