### PR TITLE
Fix breadcrumb rendering

### DIFF
--- a/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
+++ b/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
@@ -100,13 +100,7 @@ abstract class BaseBreadcrumbMenuBlockService extends AbstractBlockService imple
          */
 
         $menu = $this->factory->createItem('breadcrumb');
-
         $menu->setChildrenAttribute('class', 'breadcrumb');
-
-        if (method_exists($menu, 'setCurrentUri')) {
-            $menu->setCurrentUri($settings['current_uri']);
-        }
-
         $menu->setCurrent(true);
         $menu->setUri($settings['current_uri']);
 

--- a/src/Block/Breadcrumb/HomepageBreadcrumbBlockService.php
+++ b/src/Block/Breadcrumb/HomepageBreadcrumbBlockService.php
@@ -28,7 +28,7 @@ final class HomepageBreadcrumbBlockService extends BaseBreadcrumbMenuBlockServic
         return 'homepage';
     }
 
-    private function getMenu(BlockContextInterface $blockContext): ItemInterface
+    protected function getMenu(BlockContextInterface $blockContext): ItemInterface
     {
         $menu = $this->getRootMenu($blockContext);
 

--- a/src/Resources/config/blocks.php
+++ b/src/Resources/config/blocks.php
@@ -27,6 +27,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('sonata.breadcrumb')
             ->args([
                 new ReferenceConfigurator('twig'),
+                new ReferenceConfigurator('knp_menu.menu_provider'),
+                new ReferenceConfigurator('sonata.block.menu.registry'),
                 new ReferenceConfigurator('knp_menu.factory'),
             ]);
 };

--- a/tests/Block/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Block/Breadcrumb/BreadcrumbTest.php
@@ -15,9 +15,12 @@ namespace Sonata\SeoBundle\Tests\Block\Breadcrumb;
 
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
+use Sonata\BlockBundle\Block\BlockContext;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Model\Block;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
 use Sonata\SeoBundle\Block\Breadcrumb\BaseBreadcrumbMenuBlockService;
+use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
 
 final class BreadcrumbMenuBlockService_Test extends BaseBreadcrumbMenuBlockService
@@ -41,10 +44,57 @@ final class BreadcrumbTest extends BlockServiceTestCase
     public function testBlockService(): void
     {
         $blockService = new BreadcrumbMenuBlockService_Test(
-            $this->createMock(Environment::class),
-            $this->createMock(FactoryInterface::class)
+            $this->createStub(Environment::class),
+            $this->createStub(FactoryInterface::class)
         );
 
         static::assertTrue($blockService->handleContext('test'));
+    }
+
+    public function testBlockExectute(): void
+    {
+        $menuFactory = $this->createMock(FactoryInterface::class);
+
+        $blockService = new BreadcrumbMenuBlockService_Test(
+            $this->createStub(Environment::class),
+            $menuFactory
+        );
+
+        $menu = $this->createStub(ItemInterface::class);
+        $menuFactory->expects(static::once())->method('createItem')->with('breadcrumb')
+            ->willReturn($menu);
+
+        $blockContext = new BlockContext(new Block(), [
+            'current_uri' => null,
+            'include_homepage_link' => false,
+            'cache_policy' => 'public',
+            'template' => '@SonataBlock/Block/block_core_menu.html.twig',
+        ]);
+        $blockService->execute($blockContext, new Response());
+    }
+
+    public function testDefaultSettings(): void
+    {
+        $blockService = new BreadcrumbMenuBlockService_Test(
+            $this->createStub(Environment::class),
+            $this->createStub(FactoryInterface::class)
+        );
+
+        $blockContext = $this->getBlockContext($blockService);
+
+        $this->assertSettings([
+            'cache_policy' => 'public',
+            'template' => '@SonataBlock/Block/block_core_menu.html.twig',
+            'safe_labels' => false,
+            'current_class' => 'active',
+            'first_class' => false,
+            'last_class' => false,
+            'current_uri' => null,
+            'menu_class' => 'list-group',
+            'children_class' => 'list-group-item',
+            'menu_template' => '@SonataSeo/Block/breadcrumb.html.twig',
+            'include_homepage_link' => true,
+            'context' => null,
+        ], $blockContext);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

The `execute` method was missing, so the breadcrumb was rendered as an empty block.

This is basically a soft-port of https://github.com/sonata-project/SonataBlockBundle/blob/4.x/src/Block/Service/MenuBlockService.php.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a patch for the next stable release.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataSeoBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Mark `BaseBreadcrumbMenuBlockService::getRootMenu()` as final

### Fixed
- Fixed breadcrumb rendering
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
