### PR TITLE
Prepare 3.0.0-RC1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.0.0-RC1](https://github.com/sonata-project/SonataSeoBundle/compare/3.0.0-alpha.1...3.0.0-RC1) - 2021-11-03
+### Added
+- [[#614](https://github.com/sonata-project/SonataSeoBundle/pull/614)] Symfony 6 support ([@Kocal](https://github.com/Kocal))
+
+### Changed
+- [[#624](https://github.com/sonata-project/SonataSeoBundle/pull/624)] `BaseBreadcrumbMenuBlockService::getMenu()` method contains the root menu ([@core23](https://github.com/core23))
+- [[#620](https://github.com/sonata-project/SonataSeoBundle/pull/620)] Mark `BaseBreadcrumbMenuBlockService::getRootMenu()` as final ([@core23](https://github.com/core23))
+
+### Fixed
+- [[#620](https://github.com/sonata-project/SonataSeoBundle/pull/620)] Fixed breadcrumb rendering ([@core23](https://github.com/core23))
+
+### Removed
+- [[#622](https://github.com/sonata-project/SonataSeoBundle/pull/622)] `BaseBreadcrumbMenuBlockService::getContext` method in favor of `BreadcrumbBlockService::handleContext` ([@core23](https://github.com/core23))
+- [[#624](https://github.com/sonata-project/SonataSeoBundle/pull/624)] `BaseBreadcrumbMenuBlockService::getRootMenu()` method ([@core23](https://github.com/core23))
+
 ## [3.0.0-alpha.1](https://github.com/sonata-project/SonataSeoBundle/compare/2.14.0...3.0.0-alpha.1) - 2021-10-11
 ### Changed
 - [[#585](https://github.com/sonata-project/SonataSeoBundle/pull/585)] Added type hints to every property and method. ([@core23](https://github.com/core23))


### PR DESCRIPTION
As there is not so much activity around this project, it should be safe to create the first release candidate version.