### PR TITLE
Remove `BaseBreadcrumbMenuBlockService::getContext` method

### DIFF
--- a/docs/reference/breadcrumb.rst
+++ b/docs/reference/breadcrumb.rst
@@ -11,19 +11,20 @@ You can extend ``Sonata\SeoBundle\Block\Breadcrumb\BaseBreadcrumbMenuBlockServic
 
     namespace App\Block;
 
+    use Knp\Menu\ItemInterface;
     use Sonata\BlockBundle\Block\BlockContextInterface;
     use Sonata\SeoBundle\Block\Breadcrumb\BaseBreadcrumbMenuBlockService;
 
     class MyCustomBreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
     {
-        public function getName()
+        public function handleContext(string $context): bool
         {
-            return 'app.block.breadcrumb';
+            return 'app.block.breadcrumb' === $context;
         }
 
-        protected function getMenu(BlockContextInterface $blockContext)
+        protected function getMenu(BlockContextInterface $blockContext): ItemInterface
         {
-            $menu = $this->getRootMenu($blockContext);
+            $menu = $this->getMenu($blockContext);
 
             $menu->addChild('my_awesome_action');
 
@@ -36,10 +37,7 @@ You can extend ``Sonata\SeoBundle\Block\Breadcrumb\BaseBreadcrumbMenuBlockServic
     <!-- config/services.xml -->
 
     <service id="app.bundle.block.breadcrumb" class="App\Block\MyCustomBreadcrumbBlockService">
-        <argument>my_custom_context</argument>
-        <argument>acme.bundle.block.breadcrumb</argument>
-        <argument type="service" id="templating"/>
-        <argument type="service" id="knp_menu.menu_provider"/>
+        <argument type="service" id="twig"/>
         <argument type="service" id="knp_menu.factory"/>
         <tag name="sonata.block"/>
         <tag name="sonata.breadcrumb"/>
@@ -52,10 +50,7 @@ You can also override the breadcrumb order by defining a ``priority``:
     <!-- config/services.xml -->
 
     <service id="app.bundle.block.breadcrumb" class="App\Block\MyCustomBreadcrumbBlockService">
-        <argument>my_custom_context</argument>
-        <argument>acme.bundle.block.breadcrumb</argument>
-        <argument type="service" id="templating"/>
-        <argument type="service" id="knp_menu.menu_provider"/>
+        <argument type="service" id="twig"/>
         <argument type="service" id="knp_menu.factory"/>
         <tag name="sonata.block"/>
         <tag name="sonata.breadcrumb" priority="-127"/>

--- a/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
+++ b/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
@@ -84,7 +84,7 @@ abstract class BaseBreadcrumbMenuBlockService extends AbstractBlockService imple
         $menu->setCurrent(true);
         $menu->setUri($settings['current_uri']);
 
-        if ($settings['include_homepage_link']) {
+        if (true === $settings['include_homepage_link']) {
             $menu->addChild('sonata_seo_homepage_breadcrumb', ['uri' => '/']);
         }
 

--- a/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
+++ b/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
@@ -37,11 +37,6 @@ abstract class BaseBreadcrumbMenuBlockService extends AbstractBlockService imple
         $this->factory = $factory;
     }
 
-    public function handleContext(string $context): bool
-    {
-        return $this->getContext() === $context;
-    }
-
     final public function execute(BlockContextInterface $blockContext, ?Response $response = null): Response
     {
         $responseSettings = [
@@ -100,8 +95,6 @@ abstract class BaseBreadcrumbMenuBlockService extends AbstractBlockService imple
     {
         return $this->factory;
     }
-
-    abstract protected function getContext(): string;
 
     /**
      * Replaces setting keys with knp menu item options keys.

--- a/src/Block/Breadcrumb/HomepageBreadcrumbBlockService.php
+++ b/src/Block/Breadcrumb/HomepageBreadcrumbBlockService.php
@@ -20,8 +20,8 @@ namespace Sonata\SeoBundle\Block\Breadcrumb;
  */
 final class HomepageBreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
 {
-    protected function getContext(): string
+    public function handleContext(string $context): bool
     {
-        return 'homepage';
+        return true;
     }
 }

--- a/tests/Block/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Block/Breadcrumb/BreadcrumbTest.php
@@ -24,9 +24,9 @@ use Twig\Environment;
 
 final class BreadcrumbMenuBlockService_Test extends BaseBreadcrumbMenuBlockService
 {
-    protected function getContext(): string
+    public function handleContext(string $context): bool
     {
-        return 'test';
+        return true;
     }
 }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

There is no need for this method anymore.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is for the next major.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataSeoBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- `BaseBreadcrumbMenuBlockService::getContext` method in favor of `BreadcrumbBlockService::handleContext`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
