### PR TITLE
Remove `BaseBreadcrumbMenuBlockService::getRootMenu`

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -1,6 +1,27 @@
 UPGRADE FROM 2.X to 3.0
 =======================
 
+## Refactored `BaseBreadcrumbMenuBlockService`
+
+The class was slightly refactored, so some extension points became final.
+
+The `getRootMenu()` method was removed and the logic was moved to the `getMenu()` method. You need to call the parent method if you rely on the old logic:
+
+Before:
+```php
+protected function getMenu(BlockContextInterface $blockContext) {
+    // come custom logic
+}
+```
+After:
+```php
+protected function getMenu(BlockContextInterface $blockContext): ItemInterface {
+    parent::getMenu($blockContext);
+
+    // come custom logic
+}
+```
+
 ## SeoPage
 
 If you have implemented a custom seo page, you must adapt the signature of the following new methods to match the one in `SeoPageInterface` again:

--- a/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
+++ b/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
@@ -82,22 +82,7 @@ abstract class BaseBreadcrumbMenuBlockService extends AbstractBlockService imple
 
     protected function getMenu(BlockContextInterface $blockContext): ItemInterface
     {
-        return $this->getRootMenu($blockContext);
-    }
-
-    final protected function getFactory(): FactoryInterface
-    {
-        return $this->factory;
-    }
-
-    abstract protected function getContext(): string;
-
-    final protected function getRootMenu(BlockContextInterface $blockContext): ItemInterface
-    {
         $settings = $blockContext->getSettings();
-        /*
-         * @todo : Use the router to get the homepage URI
-         */
 
         $menu = $this->factory->createItem('breadcrumb');
         $menu->setChildrenAttribute('class', 'breadcrumb');
@@ -110,6 +95,13 @@ abstract class BaseBreadcrumbMenuBlockService extends AbstractBlockService imple
 
         return $menu;
     }
+
+    final protected function getFactory(): FactoryInterface
+    {
+        return $this->factory;
+    }
+
+    abstract protected function getContext(): string;
 
     /**
      * Replaces setting keys with knp menu item options keys.

--- a/src/Block/Breadcrumb/HomepageBreadcrumbBlockService.php
+++ b/src/Block/Breadcrumb/HomepageBreadcrumbBlockService.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\SeoBundle\Block\Breadcrumb;
 
-use Knp\Menu\ItemInterface;
-use Sonata\BlockBundle\Block\BlockContextInterface;
-
 /**
  * BlockService for homepage breadcrumb.
  *
@@ -26,12 +23,5 @@ final class HomepageBreadcrumbBlockService extends BaseBreadcrumbMenuBlockServic
     protected function getContext(): string
     {
         return 'homepage';
-    }
-
-    protected function getMenu(BlockContextInterface $blockContext): ItemInterface
-    {
-        $menu = $this->getRootMenu($blockContext);
-
-        return $menu;
     }
 }

--- a/tests/Block/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Block/Breadcrumb/BreadcrumbTest.php
@@ -16,7 +16,6 @@ namespace Sonata\SeoBundle\Tests\Block\Breadcrumb;
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
 use Sonata\BlockBundle\Block\BlockContext;
-use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\Block;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
 use Sonata\SeoBundle\Block\Breadcrumb\BaseBreadcrumbMenuBlockService;
@@ -28,11 +27,6 @@ final class BreadcrumbMenuBlockService_Test extends BaseBreadcrumbMenuBlockServi
     protected function getContext(): string
     {
         return 'test';
-    }
-
-    protected function getMenu(BlockContextInterface $blockContext): ItemInterface
-    {
-        return $this->getRootMenu($blockContext);
     }
 }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a major upgrade path.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataSeoBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- `BaseBreadcrumbMenuBlockService::getMenu()` method contains the root menu

### Removed
- `BaseBreadcrumbMenuBlockService::getRootMenu()` method
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
