### PR TITLE
Change menu label to Breadcrumb menu

### DIFF
--- a/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
+++ b/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php
@@ -55,8 +55,8 @@ abstract class BaseBreadcrumbMenuBlockService extends AbstractMenuBlockService i
      */
     public function getMetadata(): MetadataInterface
     {
-        return new Metadata('sonata.block.service.menu', null, null, 'SonataBlockBundle', [
-            'class' => 'fa fa-bars',
+        return new Metadata('sonata.seo.block.menu.breadcrumb', null, null, 'SonataSeoBundle', [
+            'class' => 'fa fa-angle-double-right',
         ]);
     }
 

--- a/src/Resources/translations/SonataSeoBundle.de.xliff
+++ b/src/Resources/translations/SonataSeoBundle.de.xliff
@@ -14,6 +14,10 @@
         <source>sonata.seo.block.email.share_button</source>
         <target>E-Mail teilen</target>
       </trans-unit>
+      <trans-unit id="sonata_seo_block_menu_breadcrumb">
+        <source>sonata.seo.block.menu.breadcrumb</source>
+        <target>Breadcrumb Menü</target>
+      </trans-unit>
       <trans-unit id="sonata_seo_block_facebook_like_box">
         <source>sonata.seo.block.facebook.like_box</source>
         <target>Facebook - Likebox</target>

--- a/src/Resources/translations/SonataSeoBundle.en.xliff
+++ b/src/Resources/translations/SonataSeoBundle.en.xliff
@@ -14,6 +14,10 @@
         <source>sonata.seo.block.email.share_button</source>
         <target>Share via E-Mail</target>
       </trans-unit>
+      <trans-unit id="sonata_seo_block_menu_breadcrumb">
+        <source>sonata.seo.block.menu.breadcrumb</source>
+        <target>Breadcrumb Menu</target>
+      </trans-unit>
       <trans-unit id="sonata_seo_block_facebook_like_box">
         <source>sonata.seo.block.facebook.like_box</source>
         <target>Facebook - Likebox</target>

--- a/src/Resources/translations/SonataSeoBundle.fr.xliff
+++ b/src/Resources/translations/SonataSeoBundle.fr.xliff
@@ -10,6 +10,10 @@
         <source>sonata_seo_share_by_email</source>
         <target>Partager par e-mail</target>
       </trans-unit>
+      <trans-unit id="sonata_seo_block_menu_breadcrumb">
+        <source>sonata.seo.block.menu.breadcrumb</source>
+        <target>Menu fil d'Ariane</target>
+      </trans-unit>
       <trans-unit id="form.label_include_homepage_link">
         <source>form.label_include_homepage_link</source>
         <target>Inclure le lien vers la page d'accueil ?</target>

--- a/src/Resources/translations/SonataSeoBundle.it.xliff
+++ b/src/Resources/translations/SonataSeoBundle.it.xliff
@@ -14,6 +14,10 @@
         <source>sonata.seo.block.email.share_button</source>
         <target>Condividi via E-Mail</target>
       </trans-unit>
+      <trans-unit id="sonata_seo_block_menu_breadcrumb">
+        <source>sonata.seo.block.menu.breadcrumb</source>
+        <target>Breadcrumb Menù</target>
+      </trans-unit>
       <trans-unit id="sonata_seo_block_facebook_like_box">
         <source>sonata.seo.block.facebook.like_box</source>
         <target>Facebook - Box like</target>

--- a/src/Resources/translations/SonataSeoBundle.nl.xliff
+++ b/src/Resources/translations/SonataSeoBundle.nl.xliff
@@ -14,6 +14,10 @@
         <source>sonata.seo.block.email.share_button</source>
         <target>Delen via e-mail</target>
       </trans-unit>
+      <trans-unit id="sonata_seo_block_menu_breadcrumb">
+        <source>sonata.seo.block.menu.breadcrumb</source>
+        <target>Breadcrumb Menu</target>
+      </trans-unit>
       <trans-unit id="sonata_seo_block_facebook_like_box">
         <source>sonata.seo.block.facebook.like_box</source>
         <target>sonata.seo.block.facebook.like_box</target>

--- a/src/Resources/translations/SonataSeoBundle.ru.xliff
+++ b/src/Resources/translations/SonataSeoBundle.ru.xliff
@@ -14,6 +14,10 @@
         <source>sonata.seo.block.email.share_button</source>
         <target>Поделиться с помощью E-Mail</target>
       </trans-unit>
+      <trans-unit id="sonata_seo_block_menu_breadcrumb">
+        <source>sonata.seo.block.menu.breadcrumb</source>
+        <target>Breadcrumb меню</target>
+      </trans-unit>
       <trans-unit id="sonata_seo_block_facebook_like_box">
         <source>sonata.seo.block.facebook.like_box</source>
         <target>Facebook - поле «Нравится»</target>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Adding a name more specific for `breadcrumb menu`

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because This issue is into this branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataSeoBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed `menu label` to `Breadcrumb menu`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

It will sove the issue when we depends the block bundle and seo bundle, like in page bundle

<img width="975" alt="Screenshot 2022-10-06 at 10 35 11" src="https://user-images.githubusercontent.com/6358755/194264518-38ac249c-c643-472c-b624-28a247e3f269.png">

