### PR TITLE
Remove deprecated spaceless tag

### DIFF
--- a/src/Resources/views/Block/breadcrumb.html.twig
+++ b/src/Resources/views/Block/breadcrumb.html.twig
@@ -23,9 +23,7 @@ file that was distributed with this source code.
 {% endblock %}
 
 {% block list %}
-{% apply spaceless %}
     <div class="sonata_breadcrumb">
         {{ parent() }}
     </div>
-{% endapply %}
 {% endblock %}

--- a/tests/DependencyInjection/Compiler/ServiceCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ServiceCompilerPassTest.php
@@ -68,8 +68,7 @@ final class ServiceCompilerPassTest extends TestCase
         (new ServiceCompilerPass())->process($container);
 
         $page = $container->get('sonata.seo.custom.page');
-
-        \assert($page instanceof SeoPageInterface);
+        static::assertInstanceOf(SeoPageInterface::class, $page);
 
         static::assertSame('Project name', $page->getOriginalTitle());
         static::assertSame('Prefix Project name Suffix', $page->getTitle());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject


Closes #{put_issue_number_here}.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataSeoBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- deprecated usages of `spaceless` twig filter
```